### PR TITLE
MP-29 Fix build without local repo

### DIFF
--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/BundleMojo.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/BundleMojo.java
@@ -148,7 +148,7 @@ public class BundleMojo extends BasePayaraMojo {
         CustomFileCopyProcessor customFileCopyProcessor = new CustomFileCopyProcessor();
         BootCommandFileCopyProcessor bootCommandFileCopyProcessor = new BootCommandFileCopyProcessor();
         DefinedArtifactDeployProcessor definedArtifactDeployProcessor = new DefinedArtifactDeployProcessor();
-        ArtifactDeployProcessor artifactDeployProcessor = new ArtifactDeployProcessor();
+        ArtifactDeployProcessor artifactDeployProcessor = new ArtifactDeployProcessor(getLog());
         StartClassCopyReplaceProcessor startClassCopyReplaceProcessor = new StartClassCopyReplaceProcessor();
         SystemPropAppendProcessor systemPropAppendProcessor = new SystemPropAppendProcessor();
         MicroJarBundleProcessor microJarBundleProcessor = new MicroJarBundleProcessor();

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/ArtifactDeployProcessor.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/ArtifactDeployProcessor.java
@@ -45,7 +45,7 @@ import org.twdata.maven.mojoexecutor.MojoExecutor;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.logging.Log;
 
 import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
 
@@ -58,6 +58,12 @@ public class ArtifactDeployProcessor extends BaseProcessor {
     private String autoDeployContextRoot;
     private Boolean autoDeployEmptyContextRoot;
     private String packaging;
+    
+    private Log log;
+
+    public ArtifactDeployProcessor(Log log) {
+        this.log = log;
+    }
 
     @Override
     public void handle(MojoExecutor.ExecutionEnvironment environment) throws MojoExecutionException {
@@ -69,8 +75,12 @@ public class ArtifactDeployProcessor extends BaseProcessor {
         if (autoDeployArtifact && WAR_EXTENSION.equalsIgnoreCase(packaging)) {
 
             String contextRoot = autoDeployContextRoot;
-            if (contextRoot == null || contextRoot.isEmpty()) {
-                if (autoDeployEmptyContextRoot || contextRoot.isEmpty() || finalName.isEmpty()) {
+            boolean contextRootSet = (contextRoot != null);
+            boolean contextRootSetButEmpty = contextRootSet && contextRoot.isEmpty();
+            if (!contextRootSet || contextRootSetButEmpty) {
+                if (autoDeployEmptyContextRoot 
+                        || contextRootSetButEmpty
+                        || finalName.isEmpty()) {
                     contextRoot = "ROOT";
                 } else {
                     contextRoot = finalName;
@@ -106,6 +116,9 @@ public class ArtifactDeployProcessor extends BaseProcessor {
                 File copiedFile = new File(copiedFileName);
                 if (copiedFile.exists()) {
                     copiedFile.setLastModified(System.currentTimeMillis());
+                    log.info("Updated timestamp of deployment file [" + copiedFile.getAbsolutePath() + "]");
+                } else {
+                    log.warn("Deployment file [" + copiedFile.getAbsolutePath() + "] doesn't exist, won't update its timestamp");
                 }
             }
         }

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/BaseProcessor.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/BaseProcessor.java
@@ -41,6 +41,7 @@ package fish.payara.maven.plugins.micro.processor;
 import fish.payara.maven.plugins.micro.Configuration;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
 
 import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
 
@@ -50,7 +51,7 @@ import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
 public abstract class BaseProcessor implements Configuration {
 
     private BaseProcessor nextProcessor;
-
+    
     Plugin dependencyPlugin =
             plugin(groupId("org.apache.maven.plugins"), artifactId("maven-dependency-plugin"), version("3.0.0"));
 


### PR DESCRIPTION
This changes lookup of main artifact file to fix behavior for points 1 and 2:

1. tries to get it from Maven API (works only if WAR built in the same lifecyle, e.g. with `mvn package payara-micro:bundle`)
2. tries to assemble the path from config in pom.xml (in case of 2 lifecycles, like `mvn package && mvn payara-micro:bundle`)
3. resorts to maven repository (works for example with `mvn clean payara-micro:bundle` if the artifact is in a maven repo already)