### PR TITLE
MP-26 Adds Custom System properties option to the bundle goal

### DIFF
--- a/payara-micro-maven-plugin/README.md
+++ b/payara-micro-maven-plugin/README.md
@@ -49,11 +49,11 @@ This goal bundles the attached project's artifact into uber jar with specified c
 
 - __autoDeployArtifact__ (optional | default: true): If the extension of the produced artifact is <b>war</b>, it will be copied automatically to ```MICRO-INF/deploy``` folder when this property is set to true.
 - __startClass__ (optional): Replaces ```Start-Class``` definition that resides in MANIFEST.MF file with the provided class.
+- __systemProperties__ (optional): Can contain a list of `property` elements that specify system properties to insert at the beginning of the ```payara-boot.properties``` file . A `property` element contains `name` and `value` elements.
 - __appendSystemProperties__ (optional | default: true): Appends all system properties defined into the ```payara-boot.properties``` file.
 - __payaraVersion__ (optional |  default: 5.182): By default ```bundle``` mojo fetches payara-micro with version 5.182.
 - __deployArtifacts__ (optional): Can contain a list of artifactItems, which defines the dependencies with their GAVs to be copied under ```MICRO-INF/deploy``` folder.
 - __customJars__ (optional): Can contain a list of artifactItems, which defines the dependencies with their GAVs to be copied under ```MICRO-INF/lib``` folder.
-- __systemProperties__ (optional): Can contain a list of `property` elements that specify system properties to add into the ```payara-boot.properties``` file . A `property` element contains `name` and `value` elements.
 
 ## start
 This goal start payara-micro with specified configurations. ```start``` is attached to the ```payara-micro``` phase. It can be executed as ```mvn payara-micro:start```. A sample usage would as follows:

--- a/payara-micro-maven-plugin/README.md
+++ b/payara-micro-maven-plugin/README.md
@@ -21,6 +21,12 @@ This goal bundles the attached project's artifact into uber jar with specified c
         </executions>
         <configuration>
             <startClass>my.custom.start.class.Main</startClass>
+            <systemProperties>
+                <property>
+                    <name>payaramicro.port</name>
+                    <value>8888</value>
+                </property>
+            </systemProperties>
             <deployArtifacts>
                 <artifactItem>
                     <groupId>org.mycompany</groupId>
@@ -47,6 +53,7 @@ This goal bundles the attached project's artifact into uber jar with specified c
 - __payaraVersion__ (optional |  default: 5.182): By default ```bundle``` mojo fetches payara-micro with version 5.182.
 - __deployArtifacts__ (optional): Can contain a list of artifactItems, which defines the dependencies with their GAVs to be copied under ```MICRO-INF/deploy``` folder.
 - __customJars__ (optional): Can contain a list of artifactItems, which defines the dependencies with their GAVs to be copied under ```MICRO-INF/lib``` folder.
+- __systemProperties__ (optional): Can contain a list of `property` elements that specify system properties to add into the ```payara-boot.properties``` file . A `property` element contains `name` and `value` elements.
 
 ## start
 This goal start payara-micro with specified configurations. ```start``` is attached to the ```payara-micro``` phase. It can be executed as ```mvn payara-micro:start```. A sample usage would as follows:

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/BundleMojo.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/BundleMojo.java
@@ -158,8 +158,8 @@ public class BundleMojo extends BasePayaraMojo {
             .next(new ArtifactDeployProcessor(getLog())).set(autoDeployArtifact, autoDeployContextRoot, 
                   autoDeployEmptyContextRoot, mavenProject.getPackaging())
             .next(new StartClassCopyReplaceProcessor()).set(startClass)
-            .next(new CustomPropPrependProcessor()).set(systemProperties)
             .next(new SystemPropAppendProcessor()).set(appendSystemProperties)
+            .next(new CustomPropPrependProcessor()).set(systemProperties)
             .next(new MicroJarBundleProcessor());
 
         return microUnpackProcessor;

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/Property.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/Property.java
@@ -36,46 +36,29 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-package fish.payara.maven.plugins.micro.processor;
-
-import fish.payara.maven.plugins.micro.Configuration;
-import org.apache.maven.model.Plugin;
-import org.apache.maven.plugin.MojoExecutionException;
-
-import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
+package fish.payara.maven.plugins.micro;
 
 /**
- * @author mertcaliskan
+ * @author ondrejmihalyi
  */
-public abstract class BaseProcessor implements Configuration {
+public class Property {
 
-    private BaseProcessor nextProcessor;
-    
-    Plugin dependencyPlugin =
-            plugin(groupId("org.apache.maven.plugins"), artifactId("maven-dependency-plugin"), version("3.1.1"));
+    private String name;
+    private String value;
 
-    Plugin resourcesPlugin =
-            plugin(groupId("org.apache.maven.plugins"), artifactId("maven-resources-plugin"), version("3.1.0"));
-
-    Plugin jarPlugin =
-            plugin(groupId("org.apache.maven.plugins"), artifactId("maven-jar-plugin"), version("3.1.0"));
-
-    Plugin replacerPlugin =
-            plugin(groupId("com.google.code.maven-replacer-plugin"), artifactId("replacer"), version("1.5.3"));
-
-    Plugin plainTextPlugin =
-            plugin(groupId("io.github.olivierlemasle.maven"), artifactId("plaintext-maven-plugin"), version("1.0.0"));
-
-    public abstract void handle(ExecutionEnvironment environment) throws MojoExecutionException;
-
-    public <PROCESSOR_TYPE extends BaseProcessor> PROCESSOR_TYPE next(PROCESSOR_TYPE processor) {
-        this.nextProcessor = processor;
-        return processor;
+    public String getName() {
+        return name;
     }
 
-    void gotoNext(ExecutionEnvironment environment) throws MojoExecutionException {
-        if (nextProcessor != null) {
-            nextProcessor.handle(environment);
-        }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
     }
 }

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/BaseSystemPropProcessor.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/BaseSystemPropProcessor.java
@@ -38,12 +38,10 @@
  */
 package fish.payara.maven.plugins.micro.processor;
 
+import java.util.*;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.twdata.maven.mojoexecutor.MojoExecutor;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Properties;
 import static org.apache.commons.lang.StringEscapeUtils.escapeJava;
 
 import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
@@ -53,9 +51,9 @@ import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
  */
 public abstract class BaseSystemPropProcessor extends BaseProcessor {
 
-    protected static final boolean APPEND = true;
+    private static final boolean APPEND = true;
 
-    protected void addSystemPropertiesForPayaraMicro(Properties properties, boolean append, MojoExecutor.ExecutionEnvironment environment) throws MojoExecutionException {
+    protected void addSystemPropertiesForPayaraMicro(Properties properties, String comment, MojoExecutor.ExecutionEnvironment environment) throws MojoExecutionException {
         executeMojo(plainTextPlugin,
                 goal("write"),
                 configuration(
@@ -63,9 +61,9 @@ public abstract class BaseSystemPropProcessor extends BaseProcessor {
                         element(name("files"),
                                 element(name("file"),
                                         element(name("name"), "payara-boot.properties"),
-                                        element(name("append"), String.valueOf(append)),
+                                        element(name("append"), String.valueOf(APPEND)),
                                         element(name("lines"),
-                                                constructElementsForProperties(properties)
+                                                constructElementsForProperties(properties, comment)
                                         )
                                 )
                         )
@@ -74,12 +72,15 @@ public abstract class BaseSystemPropProcessor extends BaseProcessor {
         );
     }
 
-    private Element[] constructElementsForProperties(Properties properties) {
+    private Element[] constructElementsForProperties(Properties properties, String comment) {
         List<Element> elements = new ArrayList<>();
-        for (Object key : properties.keySet()) {
+        String commentLine = "\n# " + ((comment != null) ? comment : "Additional properties");
+        Element emptyLine = element(name("line"), commentLine);
+        elements.add(emptyLine);
+        for (Map.Entry<Object, Object> entry : properties.entrySet()) {
             Element element = element(
                     name("line"),
-                    escapeJava(key + "=" + properties.get(key))
+                    escapeJava(entry.getKey() + "=" + entry.getValue())
             );
             elements.add(element);
         }

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/BaseSystemPropProcessor.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/BaseSystemPropProcessor.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2017-2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -38,44 +38,51 @@
  */
 package fish.payara.maven.plugins.micro.processor;
 
-import fish.payara.maven.plugins.micro.Configuration;
-import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.twdata.maven.mojoexecutor.MojoExecutor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import static org.apache.commons.lang.StringEscapeUtils.escapeJava;
 
 import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
 
 /**
- * @author mertcaliskan
+ * @author ondrejmihalyi
  */
-public abstract class BaseProcessor implements Configuration {
+public abstract class BaseSystemPropProcessor extends BaseProcessor {
 
-    private BaseProcessor nextProcessor;
-    
-    Plugin dependencyPlugin =
-            plugin(groupId("org.apache.maven.plugins"), artifactId("maven-dependency-plugin"), version("3.1.1"));
+    protected static final boolean APPEND = true;
 
-    Plugin resourcesPlugin =
-            plugin(groupId("org.apache.maven.plugins"), artifactId("maven-resources-plugin"), version("3.1.0"));
-
-    Plugin jarPlugin =
-            plugin(groupId("org.apache.maven.plugins"), artifactId("maven-jar-plugin"), version("3.1.0"));
-
-    Plugin replacerPlugin =
-            plugin(groupId("com.google.code.maven-replacer-plugin"), artifactId("replacer"), version("1.5.3"));
-
-    Plugin plainTextPlugin =
-            plugin(groupId("io.github.olivierlemasle.maven"), artifactId("plaintext-maven-plugin"), version("1.0.0"));
-
-    public abstract void handle(ExecutionEnvironment environment) throws MojoExecutionException;
-
-    public <PROCESSOR_TYPE extends BaseProcessor> PROCESSOR_TYPE next(PROCESSOR_TYPE processor) {
-        this.nextProcessor = processor;
-        return processor;
+    protected void addSystemPropertiesForPayaraMicro(Properties properties, boolean append, MojoExecutor.ExecutionEnvironment environment) throws MojoExecutionException {
+        executeMojo(plainTextPlugin,
+                goal("write"),
+                configuration(
+                        element(name("outputDirectory"), OUTPUT_FOLDER + MICROINF_FOLDER),
+                        element(name("files"),
+                                element(name("file"),
+                                        element(name("name"), "payara-boot.properties"),
+                                        element(name("append"), String.valueOf(append)),
+                                        element(name("lines"),
+                                                constructElementsForProperties(properties)
+                                        )
+                                )
+                        )
+                ),
+                environment
+        );
     }
 
-    void gotoNext(ExecutionEnvironment environment) throws MojoExecutionException {
-        if (nextProcessor != null) {
-            nextProcessor.handle(environment);
+    private Element[] constructElementsForProperties(Properties properties) {
+        List<Element> elements = new ArrayList<>();
+        for (Object key : properties.keySet()) {
+            Element element = element(
+                    name("line"),
+                    escapeJava(key + "=" + properties.get(key))
+            );
+            elements.add(element);
         }
+        return elements.toArray(new Element[elements.size()]);
     }
 }

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/CustomPropPrependProcessor.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/CustomPropPrependProcessor.java
@@ -55,7 +55,7 @@ public class CustomPropPrependProcessor extends BaseSystemPropProcessor {
     @Override
     public void handle(MojoExecutor.ExecutionEnvironment environment) throws MojoExecutionException {
         if (!properties.isEmpty()) {
-            addSystemPropertiesForPayaraMicro(toJavaProperties(properties), !APPEND, environment);
+            addSystemPropertiesForPayaraMicro(toJavaProperties(properties), "Additional custom system properties", environment);
         }
         gotoNext(environment);
     }

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/SystemPropAppendProcessor.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/SystemPropAppendProcessor.java
@@ -52,7 +52,7 @@ public class SystemPropAppendProcessor extends BaseSystemPropProcessor {
     @Override
     public void handle(MojoExecutor.ExecutionEnvironment environment) throws MojoExecutionException {
         if (appendSystemProperties) {
-            addSystemPropertiesForPayaraMicro(System.getProperties(), APPEND, environment);
+            addSystemPropertiesForPayaraMicro(System.getProperties(), "Additional system properties from Maven build", environment);
         }
         gotoNext(environment);
     }

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/SystemPropAppendProcessor.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/SystemPropAppendProcessor.java
@@ -41,42 +41,19 @@ package fish.payara.maven.plugins.micro.processor;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.twdata.maven.mojoexecutor.MojoExecutor;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Properties;
-import static org.apache.commons.lang.StringEscapeUtils.escapeJava;
-
-import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
 
 /**
  * @author mertcaliskan
  */
-public class SystemPropAppendProcessor extends BaseProcessor {
+public class SystemPropAppendProcessor extends BaseSystemPropProcessor {
 
     private Boolean appendSystemProperties;
 
     @Override
     public void handle(MojoExecutor.ExecutionEnvironment environment) throws MojoExecutionException {
         if (appendSystemProperties) {
-
-            executeMojo(plainTextPlugin,
-                    goal("write"),
-                    configuration(
-                            element(name("outputDirectory"), OUTPUT_FOLDER + MICROINF_FOLDER),
-                            element(name("files"),
-                                    element(name("file"),
-                                            element(name("name"),"payara-boot.properties"),
-                                            element(name("append"),"true"),
-                                            element(name("lines"),
-                                                    constructElementsForSystemProperties()
-                                            )
-                                    )
-                            )
-                    ),
-                    environment
-            );
+            addSystemPropertiesForPayaraMicro(System.getProperties(), APPEND, environment);
         }
-
         gotoNext(environment);
     }
 
@@ -85,16 +62,4 @@ public class SystemPropAppendProcessor extends BaseProcessor {
         return this;
     }
 
-    private Element[] constructElementsForSystemProperties() {
-        List<Element> elements = new ArrayList<>();
-        Properties properties = System.getProperties();
-        for (Object key : properties.keySet()) {
-            Element element = element(
-                    name("line"),
-                    escapeJava(key + "=" + properties.get(key))
-            );
-            elements.add(element);
-        }
-        return elements.toArray(new Element[elements.size()]);
-    }
 }


### PR DESCRIPTION
So that system props can be specified in the plugin config directly, without additional maven plugin:

```
         <systemProperties>
            <property>
                <name>payaramicro.port</name>
                <value>8888</value>
            </property>
        </systemProperties>
```

See the readme: https://github.com/OndrejM/maven-plugins/blob/cd27054c12efefacd1bf5e501c39ea50cc494070/payara-micro-maven-plugin/README.md