### PR TITLE
Problem with Integration Test using maven failsafe

### DIFF
--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/StartMojo.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/StartMojo.java
@@ -336,6 +336,7 @@ public class StartMojo extends BasePayaraMojo {
                     printStream.println(line);
                     if (!immediateExit && sb.toString().contains(MICRO_READY_MESSAGE)) {
                         microProcessorThread.interrupt();
+                        br.close()
                         break;
                     }
                 }


### PR DESCRIPTION
Integration Tests using maven failsafe and the payara-mirco-plugin hung unexpectedly. Thread-Dumps indicated a lock at the JUL. Closing the BufferedReader solves the problem. This issue occurs under Windows only. 
Java 1.8.0_172, Payara Micro 5.183, Maven 3.5.4


