### PR TITLE
Simplified generated pom.xml

### DIFF
--- a/payara-micro-maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/payara-micro-maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -10,8 +10,10 @@
     <name>${artifactId}</name>
 
     <properties>
-        <endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
         <version.javaee>${javaeeVersion}</version.javaee>
         <version.payara>${payaraMicroVersion}</version.payara>
         <version.microprofile>${microprofileVersion}</version.microprofile>
@@ -35,26 +37,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <compilerArguments>
-                        <endorseddirs>${endorsed.dir}</endorseddirs>
-                    </compilerArguments>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-war-plugin</artifactId>
-                <version>2.3</version>
-                <configuration>
-                    <failOnMissingWebXml>false</failOnMissingWebXml>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>fish.payara.maven.plugins</groupId>
                 <artifactId>payara-micro-maven-plugin</artifactId>


### PR DESCRIPTION
This moves JDK version and web.xml options outside of the plugin declaration. Also removed the "endorsed dir" setting that isn't needed.