### PR TITLE
Do not fetch transitive dependencies of payara-micro

### DIFF
--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/MicroFetchProcessor.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/MicroFetchProcessor.java
@@ -56,7 +56,8 @@ public class MicroFetchProcessor extends BaseProcessor {
                 configuration(
                     element("groupId", MICRO_GROUPID),
                     element("artifactId", MICRO_ARTIFACTID),
-                    element("version", payaraVersion)
+                    element("version", payaraVersion),
+                    element("transitive", "false")
                 ),
                 environment
         );


### PR DESCRIPTION
Transitive dependencies are not needed, and due to atypical types, they even fail when used with snapshot build like this:

````
[ERROR] Failed to execute goal fish.payara.maven.plugins:payara-micro-maven-plugin:1.0.3:start
 (default-cli) on project sample-rest-client:
Couldn't download artifact: org.eclipse.aether.resolution.DependencyResolutionException:
 Could not find artifact 
org.glassfish.main.jdbc:templates:distribution-fragment:5.192-SNAPSHOT
````