### PR TITLE
Set default context path as root

### DIFF
--- a/payara-micro-maven-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/payara-micro-maven-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -63,7 +63,7 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
             <defaultValue>false</defaultValue>
         </requiredProperty>
         <requiredProperty key="contextRoot">
-            <defaultValue>""</defaultValue>
+            <defaultValue>/</defaultValue>
         </requiredProperty>
     </requiredProperties>
     

--- a/payara-micro-maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/payara-micro-maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -91,7 +91,7 @@
                         </option>
                     </commandLineOptions>
 #end
-#if (!${contextRoot} || ${contextRoot} != "")
+#if (!${contextRoot} || ${contextRoot} != "/")
                     <contextRoot>${contextRoot}</contextRoot>
 #end
                 </configuration>


### PR DESCRIPTION
Previously `""` was written as context path, which made applications accesible at `localhost:8080/""`.