### PR TITLE
Revert "Bump maven-api.version from 3.3.9 to 3.6.3 in /payara-micro-maven-plugin"

### DIFF
--- a/payara-micro-maven-plugin/pom.xml
+++ b/payara-micro-maven-plugin/pom.xml
@@ -48,7 +48,7 @@
     <properties>
         <java.compiler.source.version>1.8</java.compiler.source.version>
         <java.compiler.target.version>1.8</java.compiler.target.version>
-        <maven-api.version>3.6.3</maven-api.version>
+        <maven-api.version>3.3.9</maven-api.version>
         <payara.version>5.201</payara.version>
     </properties>
     <scm>


### PR DESCRIPTION
Reverts payara/ecosystem-maven#140

Downgraded version as NetBeans IDE bundled with an older version of Maven build.