### PR TITLE
Overwrite Bundled Files with User Provided Files

### DIFF
--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/BootCommandFileCopyProcessor.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/BootCommandFileCopyProcessor.java
@@ -54,6 +54,7 @@ public class BootCommandFileCopyProcessor extends BaseProcessor {
                 goal("copy-resources"),
                 configuration(
                         element(name("outputDirectory"), OUTPUT_FOLDER + MICROINF_FOLDER),
+                        element(name("overwrite"), "true"),
                         element(name("resources"),
                                 element(name("resource"),
                                         element(name("directory"),  "${project.build.resources[0].directory}"),

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/CustomFileCopyProcessor.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/CustomFileCopyProcessor.java
@@ -55,6 +55,7 @@ public class CustomFileCopyProcessor extends BaseProcessor {
                 goal("copy-resources"),
                 configuration(
                         element(name("outputDirectory"), OUTPUT_FOLDER + MICROINF_DOMAIN_FOLDER),
+                        element(name("overwrite"), "true"),
                         element(name("resources"),
                             element(name("resource"), 
                                 element(name("directory"), "${project.build.resources[0].directory}"),


### PR DESCRIPTION
If users provide a file to be bundled (i.e. pre-boot-commands.txt) it
should overwrite the bundled version of the file included by default
in Payara Micro.

Closes #148 