### PR TITLE
FISH-607 Use netbeans.deploy.clientUrlPart property to set contextPath from Payara Micro Maven Plugin

### DIFF
--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/StartMojo.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/StartMojo.java
@@ -113,6 +113,13 @@ public class StartMojo extends BasePayaraMojo {
     @Parameter(property = "contextRoot")
     private String contextRoot;
 
+    /**
+     * Property passed by Apache NetBeans IDE to set contextRoot of the
+     * application
+     */
+    @Parameter(property = "netbeans.deploy.clientUrlPart")
+    private String clientUrlPart;
+
     @Deprecated
     @Parameter(property = "copySystemProperties", defaultValue = "false")
     private boolean copySystemProperties;
@@ -218,7 +225,10 @@ public class StartMojo extends BasePayaraMojo {
                     actualArgs.add(indice++, evaluateProjectArtifactAbsolutePath("." + mavenProject.getPackaging()));
                 }
             }
-            if (contextRoot != null) {
+            if(clientUrlPart != null && !clientUrlPart.trim().isEmpty()) {
+                actualArgs.add(indice++, "--contextroot");
+                actualArgs.add(indice++, clientUrlPart.trim());
+            } else if (contextRoot != null) {
                 actualArgs.add(indice++, "--contextroot");
                 actualArgs.add(indice++, contextRoot);
             }


### PR DESCRIPTION
The custom context path configured in the application property panel of  Apache NetBeans is passed via `-Dnetbeans.deploy.clientUrlPart="/my-app-context-path"` property to the command-line. So the handing of `netbeans.deploy.clientUrlPart` property is required in the Payara Micro Maven plugin alternative to `contextRoot` property.
![image](https://user-images.githubusercontent.com/15934072/95417863-b2b3de80-0953-11eb-923a-2c803b40238f.png)
