### PR TITLE
FISH-7893 Payara Micro Maven plugin - Devmode - compile and deploy application on save operation

### DIFF
--- a/payara-micro-maven-plugin/pom.xml
+++ b/payara-micro-maven-plugin/pom.xml
@@ -201,6 +201,11 @@
             <artifactId>maven-dependency-plugin</artifactId>
             <version>3.3.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-invoker</artifactId>
+            <version>3.2.0</version>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/AutoDeployHandler.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/AutoDeployHandler.java
@@ -122,7 +122,6 @@ public class AutoDeployHandler implements Runnable {
                     ENTRY_DELETE,
                     ENTRY_MODIFY);
 
-//            register(project.getBasedir().toPath());
             registerAllDirectories(sourcePath);
 
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
@@ -149,9 +148,6 @@ public class AutoDeployHandler implements Runnable {
                         WatchEvent.Kind<?> kind = event.kind();
                         Path changed = (Path) event.context();
                         Path fullPath = ((Path) key.watchable()).resolve(changed);
-//                        if (fullPath.startsWith(project.getBuild().getDirectory())) {
-//                            continue;
-//                        }
                         log.debug("Source modified: " + changed + " - " + kind);
 
                         Path projectRoot = Paths.get(project.getBasedir().toURI());

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/AutoDeployHandler.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/AutoDeployHandler.java
@@ -127,7 +127,9 @@ public class AutoDeployHandler implements Runnable {
 
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
                 try {
-                    buildReloadTask.cancel(true);
+                    if (buildReloadTask != null && !buildReloadTask.isDone()) {
+                        buildReloadTask.cancel(true);
+                    }
                     executorService.shutdown();
                 } catch (Exception ex) {
                     log.error(ex);

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/AutoDeployHandler.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/AutoDeployHandler.java
@@ -47,6 +47,7 @@ import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
@@ -344,6 +345,8 @@ public class AutoDeployHandler implements Runnable {
         public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
             try {
                 Files.delete(file);
+            } catch (NoSuchFileException e) {
+                 log.debug("Error occurred while deleting the file: ", e);
             } catch (IOException e) {
                 log.error("Error occurred while deleting the file: ", e);
             }

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/DevModeHandler.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/DevModeHandler.java
@@ -1,0 +1,207 @@
+/*
+ *
+ * Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.maven.plugins.micro;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardWatchEventKinds;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.ArrayList;
+import static java.util.Arrays.asList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.invoker.DefaultInvocationRequest;
+import org.apache.maven.shared.invoker.DefaultInvoker;
+import org.apache.maven.shared.invoker.InvocationRequest;
+import org.apache.maven.shared.invoker.InvocationResult;
+import org.apache.maven.shared.invoker.Invoker;
+import org.apache.maven.shared.invoker.MavenInvocationException;
+
+/**
+ *
+ * @author Gaurav Gupta
+ */
+public class DevModeHandler implements Runnable {
+
+    private final MavenProject project;
+    private final Log log;
+    private final ExecutorService executorService;
+    private List<String> devModeGoals;
+    private WatchService watchService;
+    private Future<?> buildReloadTask;
+    private AtomicBoolean cleanPending = new AtomicBoolean(false);
+    private ConcurrentHashMap<String, Boolean> sourceUpdatedPending = new ConcurrentHashMap<>();
+
+    public DevModeHandler(MavenProject project, Log log, String devModeGoals) {
+        this.project = project;
+        this.log = log;
+        this.devModeGoals = asList(devModeGoals.split("\\s+"));
+        this.executorService = Executors.newFixedThreadPool(2);
+    }
+
+    @Override
+    public void run() {
+        try {
+            Path sourcePath = Paths.get(project.getBasedir() + File.separator +"src");
+            this.watchService = FileSystems.getDefault().newWatchService();
+            sourcePath.register(watchService,
+                    ENTRY_CREATE,
+                    ENTRY_DELETE,
+                    ENTRY_MODIFY);
+
+            registerAllDirectories(sourcePath);
+
+            while (true) {
+                WatchKey key = watchService.poll(60, TimeUnit.SECONDS);
+                if (key != null) {
+                    if (buildReloadTask != null && !buildReloadTask.isDone()) {
+                        buildReloadTask.cancel(true);
+                    }
+                    boolean fileDeletedOrRenamed = false, resourceModified = false;
+                    boolean testClassesModified = false;
+                    List<String> goalsList = new ArrayList<>(devModeGoals);
+                    for (WatchEvent<?> event : key.pollEvents()) {
+                        WatchEvent.Kind<?> kind = event.kind();
+                        Path changed = (Path) event.context();
+                        log.info("Source modified: " + changed + " - " + kind);
+                        sourceUpdatedPending.put(changed + "-" + kind, true);
+                        Path fullPath = sourcePath.resolve(changed);
+                        Path projectRoot = Paths.get(project.getBasedir().toURI());
+                        Path resourcesDirectory = projectRoot.resolve("src").resolve("main").resolve("resources");
+                        Path testDirectory = projectRoot.resolve("src").resolve("test");
+                        
+                        if (fullPath.startsWith(resourcesDirectory)) {
+                            resourceModified = true;
+                        }
+                        if (fullPath.startsWith(testDirectory)) {
+                            testClassesModified = true;
+                        }
+                        if (kind == StandardWatchEventKinds.ENTRY_CREATE) {
+                            if (Files.isDirectory(fullPath, LinkOption.NOFOLLOW_LINKS)) {
+                                registerDirectory(fullPath);
+                            }
+                        }
+                        if (kind == StandardWatchEventKinds.ENTRY_DELETE) {
+                            fileDeletedOrRenamed = true;
+                            cleanPending.set(true);
+                        }
+                    }
+                    if (fileDeletedOrRenamed || cleanPending.get() || sourceUpdatedPending.size() > 1) {
+                        goalsList.add(0, "clean");
+                    } else if (!resourceModified) {
+                        goalsList.add("-Dmaven.resources.skip=true");
+                    }
+                    if (!testClassesModified) {
+                        goalsList.add("-Dmaven.test.skip=true");
+                    } else {
+                        goalsList.add("-DskipTests");
+                    }
+
+                    buildReloadTask = executorService.submit(() -> {
+                        InvocationRequest request = new DefaultInvocationRequest();
+                        request.setPomFile(new File(project.getBasedir(), "pom.xml"));
+                        request.setGoals(goalsList);
+                        log.info("Maven goals: " + goalsList);
+                        System.setProperty("maven.multiModuleProjectDirectory", project.getBasedir().toString());
+
+                        Invoker invoker = new DefaultInvoker();
+                        invoker.setLogger(new InvokerLoggerImpl(log));
+                        invoker.setInputStream(InputStream.nullInputStream());
+                        try {
+                            InvocationResult result = invoker.execute(request);
+                            if (result.getExitCode() != 0) {
+                                log.debug("Auto-build failed with exit code: " + result.getExitCode());
+                            } else {
+                                log.info(project.getName() + " auto-build successful");
+                                cleanPending.set(false);
+                                sourceUpdatedPending.clear();
+                                ReloadMojo reloadMojo = new ReloadMojo(project, log);
+                                try {
+                                    reloadMojo.execute();
+                                } catch (MojoExecutionException ex) {
+                                    log.error("Error invoking Reload", ex);
+                                }
+                            }
+                        } catch (MavenInvocationException ex) {
+                            log.error("Error invoking Maven", ex);
+                        }
+                    });
+                    key.reset();
+                }
+            }
+        } catch (IOException | InterruptedException ex) {
+            Logger.getLogger(DevModeHandler.class.getName()).log(Level.SEVERE, null, ex);
+        }
+    }
+
+    private void registerAllDirectories(Path path) throws IOException {
+        Files.walk(path)
+                .filter(Files::isDirectory)
+                .forEach(this::registerDirectory);
+    }
+
+    private void registerDirectory(Path dir) {
+        try {
+            dir.register(watchService, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY);
+        } catch (IOException ex) {
+            Logger.getLogger(DevModeHandler.class.getName()).log(Level.SEVERE, null, ex);
+        }
+    }
+}

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/DevMojo.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/DevMojo.java
@@ -1,0 +1,59 @@
+/*
+ *
+ * Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.maven.plugins.micro;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+
+/**
+ * Run mojo that executes payara-micro in dev mode
+ *
+ * @author Gaurav Gupta
+ */
+@Mojo(name = "dev")
+public class DevMojo extends StartMojo {
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        deployWar = true;
+        exploded = true;
+        autoDeploy = true;
+        super.execute();
+    }
+}

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/InvokerLoggerImpl.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/InvokerLoggerImpl.java
@@ -1,0 +1,140 @@
+/*
+ *
+ * Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.maven.plugins.micro;
+
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.shared.invoker.InvokerLogger;
+
+/**
+ *
+ * @author Gaurav Gupta
+ */
+public class InvokerLoggerImpl implements InvokerLogger {
+
+    private final Log log;
+
+    public InvokerLoggerImpl(Log log) {
+        this.log = log;
+    }
+
+    @Override
+    public void debug(String val) {
+        log.debug(val);
+    }
+
+    @Override
+    public void debug(String val, Throwable thrwbl) {
+        log.debug(val, thrwbl);
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return true;
+    }
+
+    @Override
+    public void info(String val) {
+        log.info(val);
+    }
+
+    @Override
+    public void info(String val, Throwable thrwbl) {
+        log.info(val, thrwbl);
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        return true;
+    }
+
+    @Override
+    public void warn(String val) {
+        log.warn(val);
+    }
+
+    @Override
+    public void warn(String val, Throwable thrwbl) {
+        log.warn(val, thrwbl);
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return true;
+    }
+
+    @Override
+    public void error(String val) {
+        log.error(val);
+    }
+
+    @Override
+    public void error(String val, Throwable thrwbl) {
+        log.error(val, thrwbl);
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return true;
+    }
+
+    @Override
+    public void fatalError(String val) {
+        log.error(val); // Assuming fatalError is treated as an error
+    }
+
+    @Override
+    public void fatalError(String val, Throwable thrwbl) {
+        log.error(val, thrwbl);
+    }
+
+    @Override
+    public boolean isFatalErrorEnabled() {
+        return true;
+    }
+
+    @Override
+    public void setThreshold(int threshold) {
+    }
+
+    @Override
+    public int getThreshold() {
+        // Implement threshold retrieval if needed
+        return 0;
+    }
+}

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/ReloadMojo.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/ReloadMojo.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2020-2021 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020-2023 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -46,12 +46,11 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.PrintWriter;
-import java.util.Date;
 import java.util.Properties;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.apache.maven.model.Build;
+import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
 
 /**
  * Reload mojo that reloads exploded web application in running payara-micro
@@ -72,6 +71,11 @@ public class ReloadMojo extends BasePayaraMojo {
 
     @Parameter(property = "metadataChanged")
     private boolean metadataChanged;
+
+    public ReloadMojo(MavenProject mavenProject, Log log) {
+        this.mavenProject = mavenProject;
+        this.setLog(log);
+    }
     
     @Override
     public void execute() throws MojoExecutionException {
@@ -90,6 +94,7 @@ public class ReloadMojo extends BasePayaraMojo {
             throw new MojoExecutionException(String.format("explodedDir[%s] not found", explodedDirPath));
         }
         File reloadFile = new File(explodedDir, RELOAD_FILE);
+        getLog().info("Reloading " + explodedDir);
         if (hotDeploy) {
             Properties props = new Properties();
             props.setProperty("hotdeploy", "true");

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/StartMojo.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/StartMojo.java
@@ -94,16 +94,16 @@ public class StartMojo extends BasePayaraMojo {
     private boolean useUberJar;
 
     @Parameter(property = "deployWar", defaultValue = "false")
-    private boolean deployWar;
+    protected boolean deployWar;
 
     /**
      * Use exploded artifact for deployment.
      */
     @Parameter(property = "exploded", defaultValue = "false")
-    private boolean exploded;
+    protected boolean exploded;
 
     @Parameter(property = "autoDeploy", defaultValue = "false")
-    private boolean autoDeploy;
+    protected boolean autoDeploy;
 
     /**
      * Attach a debugger. If set to "true", the process will suspend and wait
@@ -112,13 +112,13 @@ public class StartMojo extends BasePayaraMojo {
      *
      */
     @Parameter(property = "debug", defaultValue = "false")
-    private String debug;
+    protected String debug;
 
     @Parameter(property = "contextRoot")
     private String contextRoot;
 
     @Parameter(property = "hotDeploy")
-    private boolean hotDeploy;
+    protected boolean hotDeploy;
 
     /**
      * The directory where the webapp is built, default value is exploded war.
@@ -159,7 +159,6 @@ public class StartMojo extends BasePayaraMojo {
     public void execute() throws MojoExecutionException {
         final AutoDeployHandler autoDeployHandler;
         if (autoDeploy) {
-            exploded = true;
             autoDeployHandler = new AutoDeployHandler(this.getEnvironment().getMavenProject(), webappDirectory, this.getLog());
             Thread devModeThread = new Thread(autoDeployHandler);
             devModeThread.setDaemon(true);

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/StartMojo.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/StartMojo.java
@@ -153,14 +153,17 @@ public class StartMojo extends BasePayaraMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
+        final DevModeHandler devModeHandler;
         if (devMode) {
             if (devModeGoals.contains("exploded")) {
                 exploded = true;
             }
-            DevModeHandler devModeHandler = new DevModeHandler(this.getEnvironment().getMavenProject(), this.getLog(), devModeGoals);
+            devModeHandler = new DevModeHandler(this.getEnvironment().getMavenProject(), this.getLog(), devModeGoals);
             Thread devModeThread = new Thread(devModeHandler);
             devModeThread.setDaemon(true);
             devModeThread.start();
+        } else {
+            devModeHandler = null;
         }
 
         if (copySystemProperties) {
@@ -300,6 +303,9 @@ public class StartMojo extends BasePayaraMojo {
                 } finally {
                     microProcess.destroyForcibly();
                 }
+            }
+            if(devModeHandler != null) {
+                devModeHandler.stop();
             }
         });
 


### PR DESCRIPTION
# AutoDeploy
This pull request, linked to FISH-7893, introduces the AutoDeploy feature for the Payara Micro Maven plugin. The AutoDeploy feature enables automatic compilation and deployment of the application upon saving files within the project structure. The key commands and behaviors introduced are as follows:

### Command to Activate AutoDeploy:
To activate auto-deploy, use the following command:
````
mvn install payara-micro:start -DautoDeploy=true
````
Upon setting autoDeploy=true, the application will be automatically compiled and deployed whenever a file is saved within the project structure.

### Technical details:
##### Relies on WatchService: 
Utilizes Java's WatchService to monitor changes in source directories.
##### Continuous Build & Reload: 
Listens for file modifications and initiates builds accordingly using Maven's Invoker.
##### Goal Modification: 
Dynamically modifies Maven goals based on file modifications (e.g., cleans the project, skips tests, etc.).
##### Async Execution: 
Utilizes an ExecutorService for concurrent build tasks and asynchronous processing.
##### Project Structure Specifics: 
Registers directories and tracks changes to source, resources, and test directories.
### Limitation: 
- The autoDeploy feature is not supported for pom.xml or xxx-boot-command.txt


# DevMode
This pull request also introduces a new Mojo, DevMojo, designed to streamline development by enabling the AutoDeploy feature within the Payara Micro Maven plugin. DevMojo sets necessary configurations such as `deployWar`, `exploded`, and `autoDeploy` to `true`, facilitating rapid compilation, deployment, and file monitoring for an efficient development workflow.


### Command to start the Payara Micro instance in dev mode
To activate dev mode, use the following command:
````
mvn install payara-micro:dev
````
