### PR TITLE
Include PKCS12 Keystore

### DIFF
--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/CustomFileCopyProcessor.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/CustomFileCopyProcessor.java
@@ -62,7 +62,8 @@ public class CustomFileCopyProcessor extends BaseProcessor {
                                 element(name("includes"), 
                                     element(name("include"), "domain.xml"),
                                     element(name("include"), "hazelcast-config.xml"),
-                                    element(name("include"), "keystore.jks"), 
+                                    element(name("include"), "keystore.jks"),
+                                    element(name("include"), "keystore.p12"),
                                     element(name("include"), "login.conf"),
                                     element(name("include"), "logging.properties"),
                                     element(name("include"), "metrics.xml")


### PR DESCRIPTION
Include `keystore.p12` in addition to `keystore.jks`.  JKS is deprecated, and Payara 6+ uses PKCS12 by default.