### PR TITLE
FISH-8152 Micro Maven - Devmode - Store session state

### DIFF
--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/AutoDeployHandler.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/AutoDeployHandler.java
@@ -63,6 +63,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -345,11 +346,9 @@ public class AutoDeployHandler implements Runnable {
             log.error("Error occurred while deleting the file: ", e);
         }
     }
-    
+
     private void updateTitle(String state) {
-        if (start.getDriver() != null) {
-            ((JavascriptExecutor) start.getDriver()).executeScript(String.format("document.title = '%s %s';", state, project.getName()));
-        }
+        WebDriverFactory.executeScript(String.format("document.title = '%s %s';", state, project.getName()), start.getDriver(), log);
     }
 
     class DeleteFileVisitor extends SimpleFileVisitor<Path> {

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/AutoDeployHandler.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/AutoDeployHandler.java
@@ -305,6 +305,7 @@ public class AutoDeployHandler implements Runnable {
                     } else {
                         updateTitle("Reloading");
                         ReloadMojo reloadMojo = new ReloadMojo(project, log);
+                        reloadMojo.setKeepState(start.keepState);
                         if (start.hotDeploy) {
                             Path rootPath = project.getBasedir().toPath();
                             List<String> sourcesChanged = new ArrayList<>();

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/DevMojo.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/DevMojo.java
@@ -48,7 +48,7 @@ import org.apache.maven.plugins.annotations.Mojo;
  */
 @Mojo(name = "dev")
 public class DevMojo extends StartMojo {
-
+    
     @Override
     public void execute() throws MojoExecutionException {
         liveReload = true;
@@ -58,6 +58,7 @@ public class DevMojo extends StartMojo {
         if (trimLog == null) {
             trimLog = !getLog().isDebugEnabled();
         }
+        keepState = true;
         super.execute();
     }
 }

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/DevMojo.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/DevMojo.java
@@ -40,6 +40,7 @@ package fish.payara.maven.plugins.micro;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Run mojo that executes payara-micro in dev mode
@@ -48,17 +49,23 @@ import org.apache.maven.plugins.annotations.Mojo;
  */
 @Mojo(name = "dev")
 public class DevMojo extends StartMojo {
-    
+
     @Override
     public void execute() throws MojoExecutionException {
-        liveReload = true;
         deployWar = true;
         exploded = true;
-        autoDeploy = true;
-        if (trimLog == null) {
-            trimLog = !getLog().isDebugEnabled();
+        if (autoDeploy == null) {
+            autoDeploy = true;
         }
-        keepState = true;
+        if (liveReload == null) {
+            liveReload = true;
+        }
+        if (keepState == null) {
+            keepState = true;
+        }
+        if (trimLog == null) {
+            trimLog = true;
+        }
         super.execute();
     }
 }

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/ReloadMojo.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/ReloadMojo.java
@@ -71,6 +71,9 @@ public class ReloadMojo extends BasePayaraMojo {
 
     @Parameter(property = "metadataChanged")
     private boolean metadataChanged;
+    
+    @Parameter(property = "keepState", defaultValue = "false")
+    protected boolean keepState;
 
     public ReloadMojo(MavenProject mavenProject, Log log) {
         this.mavenProject = mavenProject;
@@ -95,14 +98,19 @@ public class ReloadMojo extends BasePayaraMojo {
         }
         File reloadFile = new File(explodedDir, RELOAD_FILE);
         getLog().info("Reloading " + explodedDir);
-        if (hotDeploy) {
+        if (hotDeploy || keepState) {
             Properties props = new Properties();
-            props.setProperty("hotdeploy", "true");
-            if (metadataChanged) {
-                props.setProperty("metadatachanged", "true");
+            if (keepState) {
+                props.setProperty("keepState", Boolean.TRUE.toString());
             }
-            if (sourcesChanged != null && !sourcesChanged.isEmpty()) {
-                props.setProperty("sourceschanged", sourcesChanged);
+            if (hotDeploy) {
+                props.setProperty("hotdeploy", Boolean.TRUE.toString());
+                if (metadataChanged) {
+                    props.setProperty("metadatachanged", Boolean.TRUE.toString());
+                }
+                if (sourcesChanged != null && !sourcesChanged.isEmpty()) {
+                    props.setProperty("sourceschanged", sourcesChanged);
+                }
             }
             try (FileOutputStream outputStrem = new FileOutputStream(reloadFile)) {
                 props.store(outputStrem, null);
@@ -131,6 +139,14 @@ public class ReloadMojo extends BasePayaraMojo {
 
     public void setHotDeploy(boolean hotDeploy) {
         this.hotDeploy = hotDeploy;
+    }
+
+    public boolean isKeepState() {
+        return keepState;
+    }
+
+    public void setKeepState(boolean keepState) {
+        this.keepState = keepState;
     }
 
     public String getSourcesChanged() {

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/StartMojo.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/StartMojo.java
@@ -111,6 +111,9 @@ public class StartMojo extends BasePayaraMojo {
 
     @Parameter(property = "autoDeploy", defaultValue = "false")
     protected boolean autoDeploy;
+    
+    @Parameter(property = "keepState", defaultValue = "false")
+    protected boolean keepState;
 
     @Parameter(property = "liveReload", defaultValue = "false")
     protected boolean liveReload;

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/StartMojo.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/StartMojo.java
@@ -109,14 +109,14 @@ public class StartMojo extends BasePayaraMojo {
     @Parameter(property = "exploded", defaultValue = "false")
     protected boolean exploded;
 
-    @Parameter(property = "autoDeploy", defaultValue = "false")
-    protected boolean autoDeploy;
+    @Parameter(property = "autoDeploy")
+    protected Boolean autoDeploy;
     
-    @Parameter(property = "keepState", defaultValue = "false")
-    protected boolean keepState;
+    @Parameter(property = "keepState")
+    protected Boolean keepState;
 
-    @Parameter(property = "liveReload", defaultValue = "false")
-    protected boolean liveReload;
+    @Parameter(property = "liveReload")
+    protected Boolean liveReload;
 
     @Parameter(property = "browser")
     protected String browser;
@@ -183,6 +183,15 @@ public class StartMojo extends BasePayaraMojo {
     public void execute() throws MojoExecutionException {
         if(trimLog == null) {
             trimLog = false;
+        }
+        if (autoDeploy == null) {
+            autoDeploy = false;
+        }
+        if (liveReload == null) {
+            liveReload = false;
+        }
+        if (keepState == null) {
+            keepState = false;
         }
         if (autoDeploy && autoDeployHandler == null) {
             autoDeployHandler = new AutoDeployHandler(this, webappDirectory);

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/StartMojo.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/StartMojo.java
@@ -530,13 +530,13 @@ public class StartMojo extends BasePayaraMojo {
                                         driver = WebDriverFactory.createWebDriver(browser);
                                         driver.get(PropertiesUtils.getProperty(payaraMicroURL, payaraMicroURL));
                                     } catch (Exception ex) {
-                                        getLog().error("Error in running WebDriver:" + ex.getMessage());
+                                        getLog().error("Error in running WebDriver" , ex);
                                         try {
                                             if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
                                                 Desktop.getDesktop().browse(new URI(payaraMicroURL));
                                             }
                                         } catch (IOException | URISyntaxException e) {
-                                            getLog().error("Error in running Desktop browse:" + e.getMessage());
+                                            getLog().error("Error in running Desktop browse", e);
                                         } finally {
                                             driver = null;
                                         }
@@ -550,7 +550,7 @@ public class StartMojo extends BasePayaraMojo {
                             try {
                                 driver.navigate().refresh();
                             } catch (Exception ex) {
-                                getLog().error("Error in refreshing with WebDriver:" + ex.getMessage());
+                                getLog().debug("Error in refreshing with WebDriver", ex);
                             }
                         } else if (autoDeploy
                                 && line.contains(INOTIFY_USER_LIMIT_REACHED_MESSAGE)) {

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/WebDriverFactory.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/WebDriverFactory.java
@@ -51,6 +51,9 @@ import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.safari.SafariDriver;
 import io.github.bonigarcia.wdm.WebDriverManager;
 import java.io.File;
+import org.apache.maven.plugin.logging.Log;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.ie.InternetExplorerDriver;
 import org.openqa.selenium.ie.InternetExplorerOptions;
 
@@ -163,6 +166,16 @@ public class WebDriverFactory {
                 }
             }
             return false;
+        }
+    }
+    
+    public static void executeScript(String script, WebDriver driver, Log log) {
+        if (driver != null && driver instanceof JavascriptExecutor) {
+            try {
+                ((JavascriptExecutor) driver).executeScript(script);
+            } catch(WebDriverException ex) {
+                log.debug(ex);
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request enhances the Micro Maven plugin for Payara Micro by introducing a new configuration property, keepState. This property allows for the persistence of session state across multiple redeployments during the development process. By default, the `keepState` property is set to `false` for the `start` mojo and `true` for the `dev` mojo.

## Use Case Testing
To validate this enhancement, a test servlet (NewServlet) has been created. The servlet utilizes the HttpSession to store and increment a session attribute ("count") with each request. The keepState property ensures that the session state is maintained across auto-reload processes, providing a seamless development experience for session-dependent functionalities.

### Instructions for Testing

#### Build Payara Micro v5.59.0-SNAPSHOT:
https://github.com/payara/Payara-Enterprise/pull/1067

#### Create the Test Servlet:
Utilize the provided NewServlet class in your project.
This servlet handles GET requests, maintains a session count, and responds with the updated count.
```

import java.io.IOException;
import java.io.PrintWriter;
import javax.servlet.ServletException;
import javax.servlet.annotation.WebServlet;
import javax.servlet.http.HttpServlet;
import javax.servlet.http.HttpServletRequest;
import javax.servlet.http.HttpServletResponse;
import javax.servlet.http.HttpSession;

@WebServlet(name = "NewServlet", urlPatterns = {"/NewServlet"})
public class NewServlet extends HttpServlet {

    @Override
    protected void doGet(HttpServletRequest request, HttpServletResponse response)
            throws ServletException, IOException {
        response.setContentType("text/html;charset=UTF-8");
        try (PrintWriter out = response.getWriter()) {
            response.setContentType("text/html;charset=UTF-8");
            HttpSession session = request.getSession(true);
            Integer count = (Integer) session.getAttribute("count");
            if (count == null) {
                count = 1;
            } else {
                count++;
            }
            session.setAttribute("count", count);
            out.println("Session Count: " + count);
        }
    }

}
```

Start Payara Micro Instance:

Use the following command to activate dev mode:

```
mvn install payara-micro:dev -DpayaraVersion=5.59.0-SNAPSHOT
```
Alternatively, for auto-deploy with hot-deploy, use the following command:
```
mvn install payara-micro:start -DautoDeploy=true -DliveReload=true -DdeployWar=true -Dexploded=true -DkeepState=true - DpayaraVersion=5.59.0-SNAPSHOT
```

The addition of the keepState property enhances the development workflow with the Micro Maven plugin, providing flexibility in managing session state persistence. 

## Depends on:
Payara Community 6 - https://github.com/payara/Payara/pull/6526
Payara Enterprise 5 - https://github.com/payara/Payara-Enterprise/pull/1067
Payara Enterprise 6 - https://payara.atlassian.net/browse/FISH-8213
