### PR TITLE
FISH-8150 Micro Maven - Devmode - Refactor Payara Micro Log Format for Improved Readability

### DIFF
--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/Configuration.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/Configuration.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2017-2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2024 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -56,6 +56,7 @@ public interface Configuration {
     String OUTPUT_FOLDER = "${project.build.directory}" + EXTRACTED_PAYARAMICRO_FOLDER;
     String METAINF_FOLDER = OUTPUT_FOLDER + File.separator + "META-INF";
 
+    String JAVA_EXECUTABLE = "java";
     String JAR_EXTENSION = "jar";
     String WAR_EXTENSION = "war";
     String MICROBUNDLE_EXTENSION = "microbundle";

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/DevMojo.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/DevMojo.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2024 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -55,6 +55,7 @@ public class DevMojo extends StartMojo {
         deployWar = true;
         exploded = true;
         autoDeploy = true;
+        trimLog = !getLog().isDebugEnabled();
         super.execute();
     }
 }

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/DevMojo.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/DevMojo.java
@@ -55,7 +55,9 @@ public class DevMojo extends StartMojo {
         deployWar = true;
         exploded = true;
         autoDeploy = true;
-        trimLog = !getLog().isDebugEnabled();
+        if (trimLog == null) {
+            trimLog = !getLog().isDebugEnabled();
+        }
         super.execute();
     }
 }

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/LogUtils.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/LogUtils.java
@@ -1,0 +1,104 @@
+/*
+ *
+ * Copyright (c) 2024 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.maven.plugins.micro;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ *
+ * @author Gaurav Gupta
+ */
+public class LogUtils {
+
+    private static final String WARNING_LEVEL = "WARNING";
+    private static final String SEVERE_LEVEL = "SEVERE";
+    private static final String LOG_REGEX = "\\[([^\\[\\]]*)\\].*(\\[.*(INFO|WARNING|SEVERE).*\\]).*\\[levelValue\\: \\d+\\](.*)";
+    private static final String WHITE_COLOR_CODE = "\033[97m" + '[';
+    private static final String YELLOW_COLOR_CODE = "\033[93m" + '[';
+    private static final String RED_COLOR_CODE = "\033[91m" + '[';
+    private static final String RESET_COLOR_CODE = ']' + "\033[0m ";
+
+    public static String trimLog(String line) {
+        Pattern pattern = Pattern.compile(LOG_REGEX);
+        Matcher matcher = pattern.matcher(line);
+        boolean find = matcher.find();
+        if (find) {
+            String timeStamp = matcher.group(1).trim();
+            String level = matcher.group(3).trim();
+            String content = matcher.group(4).trim();
+            switch (level) {
+                case WARNING_LEVEL:
+                    return warning(getTimestamp(timeStamp) + " ", content);
+                case SEVERE_LEVEL:
+                    return severe(getTimestamp(timeStamp) + " ", content);
+                default:
+                    return getTimestamp(timeStamp) + " " + content;
+            }
+        } else {
+            return line;
+        }
+    }
+
+     public static String highlightURL(String payaraMicroURL) {
+        return "\033[44m\033[97m" + payaraMicroURL + "\033[0m";
+    }
+
+    private static String warning(String timeStamp, String line) {
+        return timeStamp + YELLOW_COLOR_CODE + WARNING_LEVEL + RESET_COLOR_CODE + line;
+    }
+
+    private static String severe(String timeStamp, String line) {
+        return timeStamp + RED_COLOR_CODE + SEVERE_LEVEL + RESET_COLOR_CODE + line;
+    }
+
+    private static String getTimestamp(String timestampString) {
+        int timeStartIndex = timestampString.indexOf('T') + 1;
+        int offsetSignIndex = timestampString.indexOf('+', timeStartIndex);
+
+        // If '+' sign is not found, try '-' sign
+        if (offsetSignIndex == -1) {
+            offsetSignIndex = timestampString.indexOf('-', timeStartIndex);
+        }
+
+        String timeString = timestampString.substring(timeStartIndex, offsetSignIndex);
+
+        return WHITE_COLOR_CODE + timeString + RESET_COLOR_CODE;
+    }
+}

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/PropertiesUtils.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/PropertiesUtils.java
@@ -1,0 +1,124 @@
+/*
+ *
+ * Copyright (c) 2024 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.maven.plugins.micro;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Properties;
+
+/**
+ *
+ * @author Gaurav Gupta
+ */
+public class PropertiesUtils {
+
+    public static void saveProperties(String key, String value) {
+        String tempDir = System.getProperty("java.io.tmpdir");
+
+        // File path in the system's default temporary directory to store the properties
+        String filePath = tempDir + File.separator + "payara-maven-config.properties";
+
+        Properties prop = new Properties();
+        OutputStream output = null;
+
+        try {
+            output = new FileOutputStream(filePath);
+
+            // Set the key-value pair
+            prop.setProperty(key, value);
+
+            // Save properties to the file
+            prop.store(output, null);
+        } catch (IOException io) {
+            io.printStackTrace();
+        } finally {
+            if (output != null) {
+                try {
+                    output.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+    public static String getProperty(String key, String defaultValue) {
+
+        String tempDir = System.getProperty("java.io.tmpdir");
+
+        // File path in the system's default temporary directory to store the properties
+        String filePath = tempDir + File.separator + "payara-maven-config.properties";
+        Properties prop = new Properties();
+        InputStream input = null;
+        String value = null;
+
+        try {
+            File file = new File(filePath);
+            if (!file.exists()) {
+                saveProperties(key, key);
+            }
+            input = new FileInputStream(filePath);
+
+            // Load the properties file
+            prop.load(input);
+
+            // Get the value for the provided key
+            value = prop.getProperty(key);
+            if (value == null) {
+                value = defaultValue;
+            }
+        } catch (IOException io) {
+            io.printStackTrace();
+        } finally {
+            if (input != null) {
+                try {
+                    input.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        return value;
+    }
+
+}

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/StartMojo.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/StartMojo.java
@@ -118,8 +118,8 @@ public class StartMojo extends BasePayaraMojo {
     @Parameter(property = "browser")
     protected String browser;
 
-    @Parameter(property = "trimLog", defaultValue = "false")
-    protected boolean trimLog;
+    @Parameter(property = "trimLog")
+    protected Boolean trimLog;
 
     /**
      * Attach a debugger. If set to "true", the process will suspend and wait
@@ -178,6 +178,9 @@ public class StartMojo extends BasePayaraMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
+        if(trimLog == null) {
+            trimLog = false;
+        }
         if (autoDeploy && autoDeployHandler == null) {
             autoDeployHandler = new AutoDeployHandler(this, webappDirectory);
             Thread devModeThread = new Thread(autoDeployHandler);
@@ -504,7 +507,6 @@ public class StartMojo extends BasePayaraMojo {
                     PrintStream printStream = (PrintStream) outputStream;
 
                     while ((line = br.readLine()) != null) {
-                        printStream.println(line);
                         printStream.println(trimLog? LogUtils.trimLog(line):line);
                         if (line.contains(PAYARA_MICRO_URLS)) {
                             line = br.readLine();


### PR DESCRIPTION
This pull request introduces the trimLog property to the Payara Micro Maven plugin. When enabled (default for dev mojo, disabled for start mojo), it refactors the log format for improved readability. The `trimLog` property can be disabled in `dev` mojo if Maven is started with `-X`.

- Added trimLogs property to plugin configuration.
- Implemented logic to adjust log format based on the value of trimLogs.
- Tested compatibility with both dev and start mojo.

## Log Entry Examples:

### Original Log Entries:
```
[2024-01-18T17:22:14.559+0530] [] [INFO] [] [fish.payara.nucleus.hazelcast.HazelcastCore] [tid: _ThreadID=32 _ThreadName=RunLevelControllerThread-1705578730178] [timeMillis: 1705578734559] [levelValue: 800] JSR107 Default Cache Manager Bound to JNDI at payara/CacheManager

[2024-01-18T17:22:14.734+0530] [] [INFO] [NCLS-CORE-00101] [javax.enterprise.system.core] [tid: _ThreadID=32 _ThreadName=RunLevelControllerThread-1705578730178] [timeMillis: 1705578734734] [levelValue: 800] Network Listener http-listener started in: 18ms - bound to [/0.0.0.0:8080]

[2024-01-18T17:22:14.734+0530] [] [INFO] [NCLS-CORE-00058] [javax.enterprise.system.core] [tid: _ThreadID=32 _ThreadName=RunLevelControllerThread-1705578730178] [timeMillis: 1705578734734] [levelValue: 800] Network listener https-listener on port 8443 disabled per domain.xml

[2024-01-18T17:22:14.734+0530] [] [INFO] [NCLS-CORE-00087] [javax.enterprise.system.core] [tid: _ThreadID=32 _ThreadName=RunLevelControllerThread-1705578730178] [timeMillis: 1705578734734] [levelValue: 800] Grizzly 2.4.4 started in: 4,141ms - bound to [http-listener:8080]
```
### With `trimLog` enabled:
```
[17:22:14.559] JSR107 Default Cache Manager Bound to JNDI at payara/CacheManager

[17:22:14.734] Network Listener http-listener started in: 18ms - bound to [/0.0.0.0:8080]

[17:22:14.734] Network listener https-listener on port 8443 disabled per domain.xml

[17:22:14.734] Grizzly 2.4.4 started in: 4,141ms - bound to [http-listener:8080]
```
