### PR TITLE
Revert "Bump org.codehaus.plexus:plexus-utils from 3.4.2 to 4.0.0 in /payara-micro-maven-plugin" ad breaking org.twdata.maven:mojo-executor

### DIFF
--- a/payara-micro-maven-plugin/pom.xml
+++ b/payara-micro-maven-plugin/pom.xml
@@ -223,7 +223,7 @@
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-utils</artifactId>
-                <version>4.0.0</version>
+                <version>3.4.2</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Reverts payara/ecosystem-maven#276