### PR TITLE
FISH-8259 Improve Dev Mode Fail-Safe Mechanism

### DIFF
--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/AutoDeployHandler.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/AutoDeployHandler.java
@@ -98,6 +98,7 @@ public class AutoDeployHandler implements Runnable {
     private final List<Source> sourceUpdatedPending = new CopyOnWriteArrayList<>();
     private final AtomicBoolean stopRequested = new AtomicBoolean(false);
     private final Path buildPath;
+    private final static String RELOADING = "Reloading";
 
     public AutoDeployHandler(StartMojo start, File webappDirectory) {
         this.start = start;
@@ -198,10 +199,10 @@ public class AutoDeployHandler implements Runnable {
 
                         log.debug("sourceUpdatedPending: " + sourceUpdatedPending + " " + log);
                         if (!sourceUpdatedPending.isEmpty()) {
-                            updateTitle("Building");
+                            WebDriverFactory.updateTitle("Building", project, start.getDriver(), log);
                             log.info("Auto-build started for " + project.getName());
                             List<String> goalsList = updateGoalsList(fileDeletedOrRenamed, resourceModified, testClassesModified);
-                            log.debug("goalsList: " + goalsList);
+                            log.info("goalsList: " + goalsList);
                             executeBuildReloadTask(goalsList, rebootRequired);
                         }
                     }
@@ -291,8 +292,8 @@ public class AutoDeployHandler implements Runnable {
             try {
                 InvocationResult result = invoker.execute(request);
                 if (result.getExitCode() != 0) {
-                    log.debug("Auto-build failed with exit code: " + result.getExitCode());
-                    updateTitle("Build failed");
+                    log.info("Auto-build failed with exit code: " + result.getExitCode());
+                     WebDriverFactory.updateTitle("Build failed", project, start.getDriver(), log);
                 } else {
                     log.info("Auto-build successful for " + project.getName());
                     cleanPending.set(false);
@@ -300,12 +301,13 @@ public class AutoDeployHandler implements Runnable {
                     
                     if (rebootRequired) {
                         if (start.getMicroProcess().isAlive()) {
-                            updateTitle("Restarting");
+                            WebDriverFactory.updateTitle("Restarting", project, start.getDriver(), log);
                             start.getMicroProcess().destroy();
                         }
                     } else {
-                        updateTitle("Reloading");
+                        WebDriverFactory.updateTitle(RELOADING, project, start.getDriver(), log);
                         ReloadMojo reloadMojo = new ReloadMojo(project, log);
+                        reloadMojo.setDevMode(true);
                         reloadMojo.setKeepState(start.keepState);
                         if (start.hotDeploy) {
                             Path rootPath = project.getBasedir().toPath();
@@ -328,7 +330,6 @@ public class AutoDeployHandler implements Runnable {
                             log.error("Error invoking Reload", ex);
                         }
                     }
-
                     cleanPending.set(false);
                     sourceUpdatedPending.clear();
                 }
@@ -345,10 +346,6 @@ public class AutoDeployHandler implements Runnable {
         } catch (IOException e) {
             log.error("Error occurred while deleting the file: ", e);
         }
-    }
-
-    private void updateTitle(String state) {
-        WebDriverFactory.executeScript(String.format("document.title = '%s %s';", state, project.getName()), start.getDriver(), log);
     }
 
     class DeleteFileVisitor extends SimpleFileVisitor<Path> {

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/AutoDeployHandler.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/AutoDeployHandler.java
@@ -197,7 +197,7 @@ public class AutoDeployHandler implements Runnable {
                             }
                         }
 
-                        log.debug("sourceUpdatedPending: " + sourceUpdatedPending + " " + log);
+                        log.debug("sourceUpdatedPending: " + sourceUpdatedPending);
                         if (!sourceUpdatedPending.isEmpty()) {
                             WebDriverFactory.updateTitle("Building", project, start.getDriver(), log);
                             log.info("Auto-build started for " + project.getName());
@@ -292,8 +292,10 @@ public class AutoDeployHandler implements Runnable {
             try {
                 InvocationResult result = invoker.execute(request);
                 if (result.getExitCode() != 0) {
-                    log.info("Auto-build failed with exit code: " + result.getExitCode());
-                     WebDriverFactory.updateTitle("Build failed", project, start.getDriver(), log);
+                    if (!buildReloadTask.isCancelled()) {
+                        log.info("Auto-build failed with exit code: " + result.getExitCode());
+                        WebDriverFactory.updateTitle("Build failed", project, start.getDriver(), log);
+                    }
                 } else {
                     log.info("Auto-build successful for " + project.getName());
                     cleanPending.set(false);

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/Configuration.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/Configuration.java
@@ -64,9 +64,18 @@ public interface Configuration {
     String MICRO_THREAD_NAME = "PayaraMicroThread";
     String MICRO_READY_MESSAGE = "ready in";
     
+    // Log parser
+    String INSTANCE_CONFIGURATION = " \"Instance Configuration\": {";
+    String HOST_IP_PATTERN = "\"Host\": \"([^\"]+)\"";
+    String HOST_PORT_PATTERN = "\"Http Port\\(s\\)\": \"([^\"]+)\"";
     String PAYARA_MICRO_URLS = "Payara Micro URLs:";
+    String LOADING_APPLICATION = "Loading application";
+    String LOADING_APPLICATION_PATTERN = "Loading application \\[([^\\]]+)\\] at \\[([^\\]]+)\\]";
     String APP_DEPLOYED = "was successfully deployed";
+    String APP_DEPLOYED_PATTERN = "([^ ]+) was successfully deployed in ([^ ]+) milliseconds.";
     String INOTIFY_USER_LIMIT_REACHED_MESSAGE = "User limit of inotify instances reached";
     String WATCH_SERVICE_ERROR_MESSAGE = "Error starting WatchService. User limit of inotify instances reached or too many open files. Please increase the max_user_watches configuration.";
+    String APP_DEPLOYMENT_FAILED = "Exception while loading the app";
+    String APP_DEPLOYMENT_FAILED_MESSAGE = "Failed reloading";
 
 }

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/DevMojo.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/DevMojo.java
@@ -38,9 +38,13 @@
  */
 package fish.payara.maven.plugins.micro;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.commons.io.FileUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Run mojo that executes payara-micro in dev mode

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/LogUtils.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/LogUtils.java
@@ -76,8 +76,13 @@ public class LogUtils {
         }
     }
 
-     public static String highlightURL(String payaraMicroURL) {
-        return "\033[44m\033[97m" + payaraMicroURL + "\033[0m";
+    public static String highlight(String text) {
+        int leadingSpaces = 0;
+        while (leadingSpaces < text.length() && Character.isWhitespace(text.charAt(leadingSpaces))) {
+            leadingSpaces++;
+        }
+        String highlightedText = "\033[44m\033[97m" + text.substring(leadingSpaces) + "\033[0m";
+        return " ".repeat(leadingSpaces) + highlightedText;
     }
 
     private static String warning(String timeStamp, String line) {

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/Option.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/Option.java
@@ -46,6 +46,14 @@ public class Option {
     private String key;
     private String value;
 
+    public Option() {
+    }
+
+    public Option(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
     public String getKey() {
         return key;
     }

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/PropertiesUtils.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/PropertiesUtils.java
@@ -52,17 +52,16 @@ import java.util.Properties;
  */
 public class PropertiesUtils {
 
+    private static final String TEMP_DIR = System.getProperty("java.io.tmpdir");
+    // File path in the system's default temporary directory to store the properties
+    private static final String FILE_PATH = TEMP_DIR + File.separator + "payara-maven-config.properties";
+
     public static void saveProperties(String key, String value) {
-        String tempDir = System.getProperty("java.io.tmpdir");
-
-        // File path in the system's default temporary directory to store the properties
-        String filePath = tempDir + File.separator + "payara-maven-config.properties";
-
         Properties prop = new Properties();
         OutputStream output = null;
 
         try {
-            output = new FileOutputStream(filePath);
+            output = new FileOutputStream(FILE_PATH);
 
             // Set the key-value pair
             prop.setProperty(key, value);
@@ -84,20 +83,20 @@ public class PropertiesUtils {
 
     public static String getProperty(String key, String defaultValue) {
 
-        String tempDir = System.getProperty("java.io.tmpdir");
+        if (key == null || key.isEmpty()) {
+            return null;
+        }
 
-        // File path in the system's default temporary directory to store the properties
-        String filePath = tempDir + File.separator + "payara-maven-config.properties";
         Properties prop = new Properties();
         InputStream input = null;
         String value = null;
 
         try {
-            File file = new File(filePath);
+            File file = new File(FILE_PATH);
             if (!file.exists()) {
                 saveProperties(key, key);
             }
-            input = new FileInputStream(filePath);
+            input = new FileInputStream(FILE_PATH);
 
             // Load the properties file
             prop.load(input);

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/ReloadMojo.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/ReloadMojo.java
@@ -74,6 +74,9 @@ public class ReloadMojo extends BasePayaraMojo {
     
     @Parameter(property = "keepState", defaultValue = "false")
     protected boolean keepState;
+    
+    @Parameter(property = "devMode", defaultValue = "false")
+    protected boolean devMode;
 
     public ReloadMojo(MavenProject mavenProject, Log log) {
         this.mavenProject = mavenProject;
@@ -98,8 +101,11 @@ public class ReloadMojo extends BasePayaraMojo {
         }
         File reloadFile = new File(explodedDir, RELOAD_FILE);
         getLog().info("Reloading " + explodedDir);
-        if (hotDeploy || keepState) {
+        if (hotDeploy || keepState || devMode) {
             Properties props = new Properties();
+            if (devMode) {
+                props.setProperty("devMode", Boolean.TRUE.toString());
+            }
             if (keepState) {
                 props.setProperty("keepState", Boolean.TRUE.toString());
             }
@@ -147,6 +153,14 @@ public class ReloadMojo extends BasePayaraMojo {
 
     public void setKeepState(boolean keepState) {
         this.keepState = keepState;
+    }
+
+    public boolean isDevMode() {
+        return devMode;
+    }
+
+    public void setDevMode(boolean devMode) {
+        this.devMode = devMode;
     }
 
     public String getSourcesChanged() {

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/StartMojo.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/StartMojo.java
@@ -584,6 +584,7 @@ public class StartMojo extends BasePayaraMojo {
                 if (contextRoot != null) {
                     url = url + contextRoot;
                 }
+                payaraMicroURL = url;
             }
             driver.get(url);
         } catch (Exception ex) {

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/StartMojo.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/StartMojo.java
@@ -577,7 +577,7 @@ public class StartMojo extends BasePayaraMojo {
 
     private void openApp() {
         try {
-            driver = WebDriverFactory.createWebDriver(browser);
+            driver = WebDriverFactory.createWebDriver(browser, getLog());
             String url = PropertiesUtils.getProperty(payaraMicroURL, payaraMicroURL);
             if ((url == null || url.isEmpty()) && hostIp != null && hostPort != null) {
                 url = "http://" + hostIp + ":" + hostPort;

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/WebDriverFactory.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/WebDriverFactory.java
@@ -52,6 +52,7 @@ import org.openqa.selenium.safari.SafariDriver;
 import io.github.bonigarcia.wdm.WebDriverManager;
 import java.io.File;
 import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.ie.InternetExplorerDriver;
@@ -177,5 +178,16 @@ public class WebDriverFactory {
                 log.debug(ex);
             }
         }
+    }
+public static void updateTitle(String state, MavenProject project, WebDriver driver, Log log) {
+        WebDriverFactory.executeScript(String.format("document.title = '%s %s';", state, project.getName()), driver, log);
+    }
+    public static String getCurrentTitle(WebDriver driver) {
+        if (driver != null) {
+            if (driver instanceof JavascriptExecutor) {
+                return (String) ((JavascriptExecutor) driver).executeScript("return document.title;");
+            }
+        }
+        return null;
     }
 }

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/WebDriverFactory.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/WebDriverFactory.java
@@ -60,10 +60,10 @@ import org.openqa.selenium.ie.InternetExplorerOptions;
 
 public class WebDriverFactory {
 
-    public static WebDriver createWebDriver(String browser) {
+    public static WebDriver createWebDriver(String browser, Log log) {
         WebDriver driver = null;
         if (browser == null) {
-            browser = getDefaultBrowser();
+            browser = getDefaultBrowser(log);
         }
 
         switch (browser.toLowerCase()) {
@@ -102,23 +102,29 @@ public class WebDriverFactory {
         return driver;
     }
 
-    public static String getDefaultBrowser() {
+    public static String getDefaultBrowser(Log log) {
         if (isChromeBrowserInstalled()) {
+            log.debug("Chrome browser found");
             return "chrome";
         } else if (isFirefoxBrowserInstalled()) {
+            log.debug("Firefox browser found");
             return "firefox";
         } else {
             String os = System.getProperty("os.name").toLowerCase();
             boolean isWindows = os.contains("win");
             boolean isMac = os.contains("mac");
 
+            String defaultBrowser;
             if (isWindows) {
-                return "edge";
+                defaultBrowser = "edge";
             } else if (isMac) {
-                return "safari";
+                defaultBrowser = "safari";
             } else {
-                return "firefox";
+                defaultBrowser = "firefox";
             }
+
+            log.debug("Setting default browser: " + defaultBrowser);
+            return defaultBrowser;
         }
     }
 
@@ -169,19 +175,21 @@ public class WebDriverFactory {
             return false;
         }
     }
-    
+
     public static void executeScript(String script, WebDriver driver, Log log) {
         if (driver != null && driver instanceof JavascriptExecutor) {
             try {
                 ((JavascriptExecutor) driver).executeScript(script);
-            } catch(WebDriverException ex) {
+            } catch (WebDriverException ex) {
                 log.debug(ex);
             }
         }
     }
-public static void updateTitle(String state, MavenProject project, WebDriver driver, Log log) {
+
+    public static void updateTitle(String state, MavenProject project, WebDriver driver, Log log) {
         WebDriverFactory.executeScript(String.format("document.title = '%s %s';", state, project.getName()), driver, log);
     }
+
     public static String getCurrentTitle(WebDriver driver) {
         if (driver != null) {
             if (driver instanceof JavascriptExecutor) {


### PR DESCRIPTION
This pull request addresses the challenges faced in the Payara Micro Maven Plugin's dev mode, specifically when deployment fails after a successful build. The proposed solution introduces a fail-safe mechanism that involves the addition of a `dev-mode` flag for persistent deployment.

### Introduction of Dev Mode Flag in `.reload` file: 
Added a new dev mode flag that can be passed to Payara Micro. This flag instructs Payara Micro to persistently monitor for changes after the failure of application deployment.

### Testing Scenarios:

Implemented test cases to cover various scenarios:
- Payara Micro instance started, and application deployed:
    - Compilation/Build failed
    - Build successful but application deployment failed
- The Payara Micro instance started, but the application was not deployed due to deployment failure:
    - Compilation/Build failed
    - Build successful but application deployment failed

### Steps to create the deployment failure scenario:

Deploy the web application in dev mode with the provided CircleResource class containing a sample REST endpoint.
````
import jakarta.ws.rs.GET;
import jakarta.ws.rs.POST;
import jakarta.ws.rs.Path;
import jakarta.ws.rs.QueryParam;
import jakarta.ws.rs.core.Response;

@Path("circle")
public class CircleResource {

    @GET
    public Response calculateCircleArea(@QueryParam("radi") double radius) {
        if (radius <= 0) {
            return Response.status(Response.Status.BAD_REQUEST)
                    .entity("Radius must be a positive number.")
                    .build();
        }

        double area = Math.PI * radius * radius;
        return Response
                .ok("Area of the circle with radius " + radius + " is: " + area)
                .build();
    }
}
````
The `CircleResource` class initially has a `@GET` annotation on the `calculateCircleArea` function.

Start the application and verify the correct functioning of the REST endpoint.

#### Scenario Leading to Deployment Failure: 
4. After starting the application, dynamically modify the calculateCircleArea function by adding a `@POST` annotation to it.

5. Save the modified source file with both `@GET` and `@POST` annotations in the same function.

6. Observe that this modification results in a deployment failure and the Payara instance stops looking at the .reload file.

7. Notice that, in response to the deployment failure, the Payara Micro instance stops monitoring the .reload file, preventing subsequent deployments even after addressing the error.
    
    

### Related PRs:
https://github.com/payara/Payara/pull/6542
https://github.com/payara/Payara-Enterprise/pull/1087
    
    