### PR TITLE
FISH-7898 Payara Maven plugin - Authenticate Payara Cloud

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,14 @@
 version: 2
 updates:
 - package-ecosystem: maven
+  directory: "/payara-cloud-maven-plugin"
+  schedule:
+    interval: weekly
+    time: "03:00"
+  open-pull-requests-limit: 10
+  labels:
+  - dependencies
+- package-ecosystem: maven
   directory: "/payara-micro-maven-archetype"
   schedule:
     interval: weekly

--- a/payara-cloud-maven-plugin/pom.xml
+++ b/payara-cloud-maven-plugin/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-  Copyright (c) 2017-2021 Payara Foundation and/or its affiliates. All rights reserved.
+  Copyright (c) 2024 Payara Foundation and/or its affiliates. All rights reserved.
 
   The contents of this file are subject to the terms of either the GNU
   General Public License Version 2 only ("GPL") or the Common Development
@@ -39,17 +39,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>fish.payara.maven.plugins</groupId>
-    <artifactId>payara-micro-maven-plugin</artifactId>
-    <version>2.4-SNAPSHOT</version>
+    <artifactId>payara-cloud-maven-plugin</artifactId>
+    <version>1.0-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
-    <name>Payara Micro Maven Plugin</name>
-    <description>Payara Micro Maven Plugin that incorporates payara-micro with the produced artifact</description>
-    <url>https://github.com/payara/ecosystem-maven/tree/master/payara-micro-maven-plugin</url>
+    <name>Payara Cloud Maven Plugin</name>
+    <description>Payara Cloud Maven Plugin that deploys Jakarta EE (formerly Java EE) and MicroProfile applications to Payara Cloud, an all-in-one platform as a service (PaaS) solution</description>
+    <url>https://github.com/payara/ecosystem-maven/tree/master/payara-cloud-maven-plugin</url>
     <properties>
         <java.compiler.source.version>1.8</java.compiler.source.version>
         <java.compiler.target.version>1.8</java.compiler.target.version>
-        <maven-api.version>3.9.5</maven-api.version>
-        <payara.version>6.2024.3</payara.version>
+        <maven-api.version>3.9.6</maven-api.version>
     </properties>
     <scm>
         <connection>scm:git:https://github.com/payara/ecosystem-maven/</connection>
@@ -89,7 +88,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -118,7 +117,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.11.0</version>
+                <version>3.12.0</version>
                 <configuration>
                     <goalPrefix/>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
@@ -146,19 +145,9 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-java</artifactId>
-            <version>4.19.1</version>
-        </dependency>
-        <dependency>
-            <groupId>io.github.bonigarcia</groupId>
-            <artifactId>webdrivermanager</artifactId>
-            <version>5.7.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.11.0</version>
+            <version>3.12.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -181,31 +170,6 @@
             <artifactId>mojo-executor</artifactId>
             <version>2.4.0</version>
         </dependency>
-
-        <dependency>
-            <groupId>org.apache.maven.plugin-testing</groupId>
-            <artifactId>maven-plugin-testing-harness</artifactId>
-            <version>3.3.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-compat</artifactId>
-            <version>${maven-api.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.extras</groupId>
-            <artifactId>payara-micro</artifactId>
-            <version>${payara.version}</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>
@@ -216,29 +180,12 @@
             <artifactId>maven-invoker</artifactId>
             <version>3.2.0</version>
         </dependency>
+        <dependency>
+            <groupId>fish.payara.tools</groupId>
+            <artifactId>payara-cloud</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
     </dependencies>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-utils</artifactId>
-                <version>3.4.2</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>33.1.0-jre</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
-                <artifactId>jackson-bom</artifactId>
-                <version>2.17.0</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <profiles>
         <profile>

--- a/payara-cloud-maven-plugin/src/main/java/fish/payara/maven/plugins/cloud/BasePayaraMojo.java
+++ b/payara-cloud-maven-plugin/src/main/java/fish/payara/maven/plugins/cloud/BasePayaraMojo.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2024 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+package fish.payara.maven.plugins.cloud;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.BuildPluginManager;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.toolchain.Toolchain;
+import org.apache.maven.toolchain.ToolchainManager;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.ExecutionEnvironment;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.executionEnvironment;
+
+/**
+ * @author Gaurav Gupta
+ */
+abstract class BasePayaraMojo extends AbstractMojo {
+
+    @Component
+    MavenProject mavenProject;
+
+    @Component
+    MavenSession mavenSession;
+
+    @Component
+    private BuildPluginManager pluginManager;
+
+    @Component
+    private ToolchainManager toolchainManager;
+
+    @Parameter(property = "skip", defaultValue = "false")
+    protected boolean skip;
+
+    private ExecutionEnvironment environment;
+
+    ExecutionEnvironment getEnvironment() {
+        if (environment == null) {
+            environment = executionEnvironment(mavenProject, mavenSession, pluginManager);
+        }
+        return environment;
+    }
+    
+    protected String getProjectGAV(){
+        return mavenProject.getGroupId() + ":" + mavenProject.getArtifactId() + ":" + mavenProject.getVersion();
+    }
+
+    protected Toolchain getToolchain() {
+        if ( toolchainManager != null ) {
+            return toolchainManager.getToolchainFromBuildContext("jdk", mavenSession);
+        }
+        return null;
+    }
+}

--- a/payara-cloud-maven-plugin/src/main/java/fish/payara/maven/plugins/cloud/Configuration.java
+++ b/payara-cloud-maven-plugin/src/main/java/fish/payara/maven/plugins/cloud/Configuration.java
@@ -1,0 +1,46 @@
+/*
+ *
+ * Copyright (c) 2024 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.maven.plugins.cloud;
+
+public interface Configuration {
+
+    String APPLICATION_ID = "OPWL6h4SUxPHa1rMZ9flPStKkxnMQj8H";
+    String APPLICATION_NAME = "Payara Cloud Maven Plugin";
+
+}

--- a/payara-cloud-maven-plugin/src/main/java/fish/payara/maven/plugins/cloud/LoginMojo.java
+++ b/payara-cloud-maven-plugin/src/main/java/fish/payara/maven/plugins/cloud/LoginMojo.java
@@ -42,6 +42,7 @@ import static fish.payara.maven.plugins.cloud.Configuration.APPLICATION_NAME;
 import fish.payara.tools.cloud.LoginController;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * @author Gaurav Gupta
@@ -49,13 +50,16 @@ import org.apache.maven.plugins.annotations.Mojo;
 @Mojo(name = "login")
 public class LoginMojo extends BasePayaraMojo {
 
+    @Parameter(property = "intractive", defaultValue = "true")
+    private boolean intractive;
+
     @Override
     public void execute() throws MojoExecutionException {
         if (skip) {
             getLog().info("Login mojo execution is skipped");
             return;
         }
-        LoginController controller = new LoginController(APPLICATION_ID, APPLICATION_NAME, true);
+        LoginController controller = new LoginController(APPLICATION_ID, APPLICATION_NAME, intractive);
         controller.login();
     }
 

--- a/payara-cloud-maven-plugin/src/main/java/fish/payara/maven/plugins/cloud/LoginMojo.java
+++ b/payara-cloud-maven-plugin/src/main/java/fish/payara/maven/plugins/cloud/LoginMojo.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+package fish.payara.maven.plugins.cloud;
+
+import static fish.payara.maven.plugins.cloud.Configuration.APPLICATION_ID;
+import static fish.payara.maven.plugins.cloud.Configuration.APPLICATION_NAME;
+import fish.payara.tools.cloud.LoginController;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+
+/**
+ * @author Gaurav Gupta
+ */
+@Mojo(name = "login")
+public class LoginMojo extends BasePayaraMojo {
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        if (skip) {
+            getLog().info("Login mojo execution is skipped");
+            return;
+        }
+        LoginController controller = new LoginController(APPLICATION_ID, APPLICATION_NAME, true);
+        controller.login();
+    }
+
+}

--- a/payara-micro-maven-archetype/pom.xml
+++ b/payara-micro-maven-archetype/pom.xml
@@ -42,7 +42,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>fish.payara.maven.archetypes</groupId>
     <artifactId>payara-micro-maven-archetype</artifactId>
-    <version>2.3</version>
+    <version>2.4-SNAPSHOT</version>
     <packaging>maven-archetype</packaging>
     <name>Payara Micro Archetype</name>
     <description>Archetype for Payara Micro application.</description>


### PR DESCRIPTION
This PR adds initial features to authenticate devices for Cloud operation.

 - To test it build the PR Ecosystem-Cloud (https://github.com/payara/ecosystem-cloud/pull/1) and this PR (https://github.com/payara/ecosystem-maven/pull/324).
-  Run the following command and it will open the browser to follow the auth process.
`mvn fish.payara.maven.plugins:payara-cloud-maven-plugin:1.0-SNAPSHOT:login`