### PR TITLE
FISH-7900 Payara Maven plugin - Deploy/Undeploy application to Payara Cloud

### DIFF
--- a/payara-cloud-maven-plugin/pom.xml
+++ b/payara-cloud-maven-plugin/pom.xml
@@ -194,7 +194,6 @@
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-web-api</artifactId>
             <version>8.0.0</version>
-            <type>jar</type>
         </dependency>
     </dependencies>
 

--- a/payara-cloud-maven-plugin/pom.xml
+++ b/payara-cloud-maven-plugin/pom.xml
@@ -185,6 +185,17 @@
             <artifactId>payara-cloud</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>fish.payara.cloud</groupId>
+            <artifactId>cloud-api</artifactId>
+            <version>1.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-web-api</artifactId>
+            <version>8.0.0</version>
+            <type>jar</type>
+        </dependency>
     </dependencies>
 
     <profiles>
@@ -277,4 +288,10 @@
             </build>
         </profile>
     </profiles>
+    <repositories>
+        <repository>
+            <id>payara-nexus-releases</id>
+            <url>https://nexus.dev.payara.fish/repository/payara-artifacts/</url>
+        </repository>
+    </repositories>
 </project>

--- a/payara-cloud-maven-plugin/src/main/java/fish/payara/maven/plugins/cloud/BasePayaraMojo.java
+++ b/payara-cloud-maven-plugin/src/main/java/fish/payara/maven/plugins/cloud/BasePayaraMojo.java
@@ -37,6 +37,9 @@
  */
 package fish.payara.maven.plugins.cloud;
 
+import static fish.payara.maven.plugins.cloud.Configuration.CLIENT_ID;
+import static fish.payara.maven.plugins.cloud.Configuration.CLIENT_NAME;
+import fish.payara.tools.cloud.ApplicationContext;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.BuildPluginManager;
@@ -68,7 +71,31 @@ abstract class BasePayaraMojo extends AbstractMojo {
     @Parameter(property = "skip", defaultValue = "false")
     protected boolean skip;
 
+    @Parameter(property = "subscriptionId")
+    protected String subscriptionId;
+
+    @Parameter(property = "namespaceId")
+    protected String namespaceId;
+
+    @Parameter(defaultValue = "${project.artifactId}", property = "applicationName", required = true)
+    protected String applicationName;
+    
+    @Parameter(property = "intractive", defaultValue = "true")
+    protected boolean intractive;
+
     private ExecutionEnvironment environment;
+    
+    protected ApplicationContext.Builder getApplicationContextBuilder() {
+        ApplicationContext.Builder builder = ApplicationContext.builder(CLIENT_ID, CLIENT_NAME, intractive)
+                .applicationName(applicationName);
+        if (subscriptionId != null) {
+            builder.subscriptionId(subscriptionId);
+        }
+        if (namespaceId != null) {
+            builder.subscriptionId(namespaceId);
+        }
+        return builder;
+    }
 
     protected ExecutionEnvironment getEnvironment() {
         if (environment == null) {

--- a/payara-cloud-maven-plugin/src/main/java/fish/payara/maven/plugins/cloud/Configuration.java
+++ b/payara-cloud-maven-plugin/src/main/java/fish/payara/maven/plugins/cloud/Configuration.java
@@ -40,7 +40,7 @@ package fish.payara.maven.plugins.cloud;
 
 public interface Configuration {
 
-    String APPLICATION_ID = "OPWL6h4SUxPHa1rMZ9flPStKkxnMQj8H";
-    String APPLICATION_NAME = "Payara Cloud Maven Plugin";
+    String CLIENT_ID = "qeqSpqVZtHGbr0YU75Z9p87HMle0RA5a";
+    String CLIENT_NAME = "Payara Cloud Maven Plugin";
 
 }

--- a/payara-cloud-maven-plugin/src/main/java/fish/payara/maven/plugins/cloud/DeployMojo.java
+++ b/payara-cloud-maven-plugin/src/main/java/fish/payara/maven/plugins/cloud/DeployMojo.java
@@ -43,6 +43,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import static fish.payara.maven.plugins.cloud.Configuration.CLIENT_ID;
 import static fish.payara.maven.plugins.cloud.Configuration.CLIENT_NAME;
 import fish.payara.tools.cloud.ApplicationContext;
+import fish.payara.tools.cloud.ApplicationContext.Builder;
 import fish.payara.tools.cloud.DeployApplication;
 import java.io.File;
 
@@ -52,21 +53,13 @@ import java.io.File;
 @Mojo(name = "deploy")
 public class DeployMojo extends BasePayaraMojo {
 
-    @Parameter(property = "intractive", defaultValue = "true")
-    private boolean intractive;
 
     @Parameter(defaultValue = "${project.build.directory}/${project.build.finalName}.war", property = "applicationPath", required = true)
     protected File applicationPath;
     
-    
-    @Parameter(defaultValue = "${project.artifactId}", property = "applicationName", required = true)
-    protected String applicationName;
-
     @Override
     public void execute() throws MojoExecutionException {
-        ApplicationContext context = ApplicationContext.builder(CLIENT_ID, CLIENT_NAME, intractive)
-                    .applicationName(applicationName)
-                    .build();
+        ApplicationContext context = getApplicationContextBuilder().build();
         try {
             if (skip) {
                 getLog().info("Deploy mojo execution is skipped");

--- a/payara-cloud-maven-plugin/src/main/java/fish/payara/maven/plugins/cloud/LoginMojo.java
+++ b/payara-cloud-maven-plugin/src/main/java/fish/payara/maven/plugins/cloud/LoginMojo.java
@@ -51,9 +51,6 @@ import fish.payara.tools.cloud.ApplicationContext;
 @Mojo(name = "login")
 public class LoginMojo extends BasePayaraMojo {
 
-    @Parameter(property = "intractive", defaultValue = "true")
-    private boolean intractive;
-
     @Override
     public void execute() throws MojoExecutionException {
         if (skip) {

--- a/payara-cloud-maven-plugin/src/main/java/fish/payara/maven/plugins/cloud/LoginMojo.java
+++ b/payara-cloud-maven-plugin/src/main/java/fish/payara/maven/plugins/cloud/LoginMojo.java
@@ -37,12 +37,13 @@
  */
 package fish.payara.maven.plugins.cloud;
 
-import static fish.payara.maven.plugins.cloud.Configuration.APPLICATION_ID;
-import static fish.payara.maven.plugins.cloud.Configuration.APPLICATION_NAME;
 import fish.payara.tools.cloud.LoginController;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import static fish.payara.maven.plugins.cloud.Configuration.CLIENT_ID;
+import static fish.payara.maven.plugins.cloud.Configuration.CLIENT_NAME;
+import fish.payara.tools.cloud.ApplicationContext;
 
 /**
  * @author Gaurav Gupta
@@ -59,8 +60,9 @@ public class LoginMojo extends BasePayaraMojo {
             getLog().info("Login mojo execution is skipped");
             return;
         }
-        LoginController controller = new LoginController(APPLICATION_ID, APPLICATION_NAME, intractive);
-        controller.login();
+        ApplicationContext context = ApplicationContext.builder(CLIENT_ID, CLIENT_NAME, intractive).build();
+        LoginController controller = new LoginController(context);
+        controller.call();
     }
 
 }

--- a/payara-cloud-maven-plugin/src/main/java/fish/payara/maven/plugins/cloud/UndeployMojo.java
+++ b/payara-cloud-maven-plugin/src/main/java/fish/payara/maven/plugins/cloud/UndeployMojo.java
@@ -37,11 +37,11 @@
  */
 package fish.payara.maven.plugins.cloud;
 
+import static fish.payara.maven.plugins.cloud.Configuration.CLIENT_ID;
+import static fish.payara.maven.plugins.cloud.Configuration.CLIENT_NAME;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import static fish.payara.maven.plugins.cloud.Configuration.CLIENT_ID;
-import static fish.payara.maven.plugins.cloud.Configuration.CLIENT_NAME;
 import fish.payara.tools.cloud.ApplicationContext;
 import fish.payara.tools.cloud.DeleteApplication;
 
@@ -51,17 +51,9 @@ import fish.payara.tools.cloud.DeleteApplication;
 @Mojo(name = "undeploy")
 public class UndeployMojo extends BasePayaraMojo {
 
-    @Parameter(property = "intractive", defaultValue = "true")
-    private boolean intractive;
-
-    @Parameter(defaultValue = "${project.artifactId}", property = "applicationName", required = true)
-    protected String applicationName;
-
     @Override
     public void execute() throws MojoExecutionException {
-        ApplicationContext context = ApplicationContext.builder(CLIENT_ID, CLIENT_NAME, intractive)
-                    .applicationName(applicationName)
-                    .build();
+        ApplicationContext context = getApplicationContextBuilder().build();
         try {
             if (skip) {
                 getLog().info("Undeploy mojo execution is skipped");

--- a/payara-cloud-maven-plugin/src/main/java/fish/payara/maven/plugins/cloud/UndeployMojo.java
+++ b/payara-cloud-maven-plugin/src/main/java/fish/payara/maven/plugins/cloud/UndeployMojo.java
@@ -37,54 +37,41 @@
  */
 package fish.payara.maven.plugins.cloud;
 
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.AbstractMojo;
-import org.apache.maven.plugin.BuildPluginManager;
-import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.project.MavenProject;
-import org.apache.maven.toolchain.Toolchain;
-import org.apache.maven.toolchain.ToolchainManager;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.ExecutionEnvironment;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.executionEnvironment;
+import static fish.payara.maven.plugins.cloud.Configuration.CLIENT_ID;
+import static fish.payara.maven.plugins.cloud.Configuration.CLIENT_NAME;
+import fish.payara.tools.cloud.ApplicationContext;
+import fish.payara.tools.cloud.DeleteApplication;
 
 /**
  * @author Gaurav Gupta
  */
-abstract class BasePayaraMojo extends AbstractMojo {
+@Mojo(name = "undeploy")
+public class UndeployMojo extends BasePayaraMojo {
 
-    @Component
-    MavenProject mavenProject;
+    @Parameter(property = "intractive", defaultValue = "true")
+    private boolean intractive;
 
-    @Component
-    MavenSession mavenSession;
+    @Parameter(defaultValue = "${project.artifactId}", property = "applicationName", required = true)
+    protected String applicationName;
 
-    @Component
-    private BuildPluginManager pluginManager;
-
-    @Component
-    private ToolchainManager toolchainManager;
-
-    @Parameter(property = "skip", defaultValue = "false")
-    protected boolean skip;
-
-    private ExecutionEnvironment environment;
-
-    protected ExecutionEnvironment getEnvironment() {
-        if (environment == null) {
-            environment = executionEnvironment(mavenProject, mavenSession, pluginManager);
+    @Override
+    public void execute() throws MojoExecutionException {
+        ApplicationContext context = ApplicationContext.builder(CLIENT_ID, CLIENT_NAME, intractive)
+                    .applicationName(applicationName)
+                    .build();
+        try {
+            if (skip) {
+                getLog().info("Undeploy mojo execution is skipped");
+                return;
+            }
+            DeleteApplication controller = new DeleteApplication(context);
+            controller.call();
+        }catch (Exception ex) {
+            context.getOutput().error(ex.toString(), ex);
         }
-        return environment;
-    }
-    
-    protected String getProjectGAV(){
-        return mavenProject.getGroupId() + ":" + mavenProject.getArtifactId() + ":" + mavenProject.getVersion();
     }
 
-    protected Toolchain getToolchain() {
-        if ( toolchainManager != null ) {
-            return toolchainManager.getToolchainFromBuildContext("jdk", mavenSession);
-        }
-        return null;
-    }
 }

--- a/payara-cloud-maven-plugin/src/main/java/fish/payara/maven/plugins/cloud/UndeployMojo.java
+++ b/payara-cloud-maven-plugin/src/main/java/fish/payara/maven/plugins/cloud/UndeployMojo.java
@@ -68,7 +68,9 @@ public class UndeployMojo extends BasePayaraMojo {
                 return;
             }
             DeleteApplication controller = new DeleteApplication(context);
-            controller.call();
+            if(controller.call() == 0) {
+                getLog().info("Application undeployed successfully.");
+            }
         }catch (Exception ex) {
             context.getOutput().error(ex.toString(), ex);
         }


### PR DESCRIPTION
This PR adds initial features to deploy/undeploy applications to Payara Cloud:

 - To test it build the PR Ecosystem-Cloud (https://github.com/payara/ecosystem-cloud/pull/2) and this PR.
-  Run the following command and it will open the browser to follow the auth process and deploy application.
`mvn fish.payara.maven.plugins:payara-cloud-maven-plugin:1.0-SNAPSHOT:deploy`

![image](https://github.com/payara/ecosystem-maven/assets/15934072/21945be3-5e12-4421-8c5a-9f1e8fa547fc)
![image](https://github.com/payara/ecosystem-maven/assets/15934072/d86f2f5f-818e-4d59-924e-3ad09464b0a3)
