### PR TITLE
FISH-10239 Start and Stop Local Payara Server using Payara Server Maven Plugin

### DIFF
--- a/payara-server-maven-plugin/pom.xml
+++ b/payara-server-maven-plugin/pom.xml
@@ -1,0 +1,322 @@
+<!--
+
+  Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+
+  The contents of this file are subject to the terms of either the GNU
+  General Public License Version 2 only ("GPL") or the Common Development
+  and Distribution License("CDDL") (collectively, the "License").  You
+  may not use this file except in compliance with the License.  You can
+  obtain a copy of the License at
+  https://github.com/payara/Payara/blob/master/LICENSE.txt
+  See the License for the specific
+  language governing permissions and limitations under the License.
+
+  When distributing the software, include this License Header Notice in each
+  file and include the License file at glassfish/legal/LICENSE.txt.
+
+  GPL Classpath Exception:
+  The Payara Foundation designates this particular file as subject to the "Classpath"
+  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  file that accompanied this code.
+
+  Modifications:
+  If applicable, add the following below the License Header, with the fields
+  enclosed by brackets [] replaced by your own identifying information:
+  "Portions Copyright [year] [name of copyright owner]"
+
+  Contributor(s):
+  If you wish your version of this file to be governed by only the CDDL or
+  only the GPL Version 2, indicate your decision by adding "[Contributor]
+  elects to include this software in this distribution under the [CDDL or GPL
+  Version 2] license."  If you don't indicate a single choice of license, a
+  recipient has the option to distribute your version of this file under
+  either the CDDL, the GPL Version 2 or to extend the choice of license to
+  its licensees as provided above.  However, if you add GPL Version 2 code
+  and therefore, elected the GPL Version 2 license, then the option applies
+  only if the new code is made subject to such option by the copyright
+  holder.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>fish.payara.maven.plugins</groupId>
+    <artifactId>payara-server-maven-plugin</artifactId>
+    <version>1.0.0-Alpha1</version>
+    <packaging>maven-plugin</packaging>
+    <name>Payara Server Maven Plugin</name>
+    <description>Payara Server Maven Plugin that incorporates Payara Server with the produced artifact</description>
+    <url>https://github.com/payara/ecosystem-maven/tree/master/payara-server-maven-plugin</url>
+    <properties>
+        <java.compiler.source.version>1.8</java.compiler.source.version>
+        <java.compiler.target.version>1.8</java.compiler.target.version>
+        <maven-api.version>3.9.5</maven-api.version>
+        <payara.version>6.2024.7</payara.version>
+    </properties>
+    <scm>
+        <connection>scm:git:https://github.com/payara/ecosystem-maven/</connection>
+        <url>https://github.com/payara/ecosystem-maven/</url>
+        <developerConnection>scm:git:https://github.com/payara/ecosystem-maven/</developerConnection>
+    </scm>
+    <licenses>
+        <license>
+            <name>CDDL + GPLv2 with classpath exception</name>
+            <url>https://raw.githubusercontent.com/payara/Payara/master/LICENSE.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <id>jgauravgupta</id>
+            <name>Gaurav Gupta</name>
+            <organization>Payara</organization>
+            <timezone>GMT+5.5</timezone>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </developer>
+    </developers>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <source>${java.compiler.source.version}</source>
+                    <target>${java.compiler.target.version}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.3.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.8.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <source>8</source>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>3.13.1</version>
+                <configuration>
+                    <goalPrefix/>
+                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>mojo-descriptor</id>
+                        <goals>
+                            <goal>descriptor</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>3.1.1</version>
+                <configuration>
+                    <pushChanges>false</pushChanges>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <localCheckout>true</localCheckout>
+                    <releaseProfiles>release</releaseProfiles>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.13.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>${maven-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>${maven-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>${maven-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.twdata.maven</groupId>
+            <artifactId>mojo-executor</artifactId>
+            <version>2.4.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.plugin-testing</groupId>
+            <artifactId>maven-plugin-testing-harness</artifactId>
+            <version>3.3.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-compat</artifactId>
+            <version>${maven-api.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <version>3.7.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-invoker</artifactId>
+            <version>3.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.maven.plugins</groupId>
+            <artifactId>payara-maven-plugins-common</artifactId>
+            <version>1.0-Alpha4</version>
+        </dependency>
+    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-utils</artifactId>
+                <version>3.4.2</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>33.1.0-jre</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>2.17.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.2.4</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>payara-enterprise</id>
+            <distributionManagement>
+                <repository>
+                    <id>payara-enterprise</id>
+                    <name>Payara Enterprise Nexus</name>
+                    <url>https://nexus.payara.fish/content/repositories/payara-enterprise</url>
+                </repository>
+            </distributionManagement>
+            <repositories>
+                <repository>
+                    <id>payara-enterprise</id>
+                    <name>Payara Enterprise Nexus</name>
+                    <url>https://nexus.payara.fish/content/repositories/payara-enterprise</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+        </profile>
+        <profile>
+            <id>payara-community</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <distributionManagement>
+                <snapshotRepository>
+                    <id>ossrh</id>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+                </snapshotRepository>
+                <repository>
+                    <id>ossrh</id>
+                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+                </repository>
+            </distributionManagement>
+            <repositories>
+                <repository>
+                    <id>central</id>
+                    <name>Central Repository</name>
+                    <url>https://repo.maven.apache.org/maven2</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.7.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/BasePayaraMojo.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/BasePayaraMojo.java
@@ -1,0 +1,89 @@
+/*
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.maven.plugins.server;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.BuildPluginManager;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.toolchain.Toolchain;
+import org.apache.maven.toolchain.ToolchainManager;
+
+import static org.twdata.maven.mojoexecutor.MojoExecutor.ExecutionEnvironment;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.executionEnvironment;
+
+abstract class BasePayaraMojo extends AbstractMojo {
+
+    @Component
+    MavenProject mavenProject;
+
+    @Component
+    MavenSession mavenSession;
+
+    @Component
+    private BuildPluginManager pluginManager;
+
+    @Component
+    private ToolchainManager toolchainManager;
+
+    @Parameter(property = "skip", defaultValue = "false")
+    protected boolean skip;
+
+    private ExecutionEnvironment environment;
+
+    ExecutionEnvironment getEnvironment() {
+        if (environment == null) {
+            environment = executionEnvironment(mavenProject, mavenSession, pluginManager);
+        }
+        return environment;
+    }
+    
+    protected String getProjectGAV(){
+        return mavenProject.getGroupId() + ":" + mavenProject.getArtifactId() + ":" + mavenProject.getVersion();
+    }
+
+    protected Toolchain getToolchain() {
+        if ( toolchainManager != null ) {
+            return toolchainManager.getToolchainFromBuildContext("jdk", mavenSession);
+        }
+        return null;
+    }
+}

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/BaseProcessor.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/BaseProcessor.java
@@ -1,0 +1,65 @@
+/*
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.maven.plugins.server;
+
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.MojoExecutionException;
+
+import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
+
+public abstract class BaseProcessor implements Configuration {
+
+    private BaseProcessor nextProcessor;
+    
+    Plugin dependencyPlugin =
+            plugin(groupId("org.apache.maven.plugins"), artifactId("maven-dependency-plugin"), version("3.8.1"));
+
+    public abstract void handle(ExecutionEnvironment environment) throws MojoExecutionException;
+
+    public <PROCESSOR_TYPE extends BaseProcessor> PROCESSOR_TYPE next(PROCESSOR_TYPE processor) {
+        this.nextProcessor = processor;
+        return processor;
+    }
+
+    void gotoNext(ExecutionEnvironment environment) throws MojoExecutionException {
+        if (nextProcessor != null) {
+            nextProcessor.handle(environment);
+        }
+    }
+}

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/Configuration.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/Configuration.java
@@ -1,0 +1,70 @@
+/*
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.maven.plugins.server;
+
+import java.io.File;
+
+public interface Configuration {
+    String SERVER_GROUPID = "fish.payara.distributions";
+    String SERVER_ARTIFACTID = "payara";
+    
+    String DAS_NAME = "server";
+
+    String JAVA_EXECUTABLE = "java";
+    String JAR_EXTENSION = "jar";
+    String WAR_EXTENSION = "war";
+
+    String SERVER_THREAD_NAME = "PayaraServerThread";
+    String SERVER_READY_MESSAGE = "ready in";
+    
+    // Log parser
+    String INSTANCE_CONFIGURATION = " \"Instance Configuration\": {";
+    String HOST_IP_PATTERN = "\"Host\": \"([^\"]+)\"";
+    String HOST_PORT_PATTERN = "\"Http Port\\(s\\)\": \"([^\"]+)\"";
+    String PAYARA_SERVER_URLS = "Payara Server URLs:";
+    String LOADING_APPLICATION = "Loading application";
+    String LOADING_APPLICATION_PATTERN = "Loading application \\[([^\\]]+)\\] at \\[([^\\]]+)\\]";
+    String APP_DEPLOYED = "was successfully deployed";
+    String APP_DEPLOYED_PATTERN = "([^ ]+) was successfully deployed in ([^ ]+) milliseconds.";
+    String INOTIFY_USER_LIMIT_REACHED_MESSAGE = "User limit of inotify instances reached";
+    String WATCH_SERVICE_ERROR_MESSAGE = "Error starting WatchService. User limit of inotify instances reached or too many open files. Please increase the max_user_watches configuration.";
+    String APP_DEPLOYMENT_FAILED = "Exception while loading the app";
+    String APP_DEPLOYMENT_FAILED_MESSAGE = "Failed reloading";
+
+}

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/PayaraServerInstance.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/PayaraServerInstance.java
@@ -1,0 +1,174 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package fish.payara.maven.plugins.server;
+
+import fish.payara.maven.plugins.server.parser.JDKVersion;
+import fish.payara.maven.plugins.server.parser.PortReader;
+import static fish.payara.maven.plugins.server.Configuration.DAS_NAME;
+import java.nio.file.Paths;
+
+/**
+ *
+ * @author Gaurav Gupta
+ */
+public class PayaraServerInstance {
+    
+        private PortReader portReader;
+    private Process logStream;
+
+    private String path;
+    private String domainName;
+    private String jdkHome;
+    
+    public PayaraServerInstance(String domainName, String path) {
+        this.path = path;
+         this.domainName = domainName;
+    }
+
+    public String getId() {
+        return getDomainPath();
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public String getDomainName() {
+        return domainName;
+    }
+
+    public String getServerRoot() {
+        return getPath();
+    }
+
+    public String getServerHome() {
+        return Paths.get(getServerRoot(), "glassfish").toString();
+    }
+
+    public String getServerModules() {
+        return Paths.get(getServerHome(), "modules").toString();
+    }
+
+    public String getDomainsFolder() {
+        return Paths.get(getServerHome(), "domains").toString();
+    }
+
+    public String getDomainPath() {
+        return Paths.get(getDomainsFolder(), getDomainName()).toString();
+    }
+
+    public String getDomainXmlPath() {
+        return Paths.get(getDomainPath(), "config", "domain.xml").toString();
+    }
+
+    public String getServerLog() {
+        return Paths.get(getDomainPath(), "logs", "server.log").toString();
+    }
+    
+    
+    public String getJDKHome() {
+        if (this.jdkHome != null) {
+            return this.jdkHome;
+        }
+        return JDKVersion.getDefaultJDKHome();
+    }
+
+//    @Override
+//    public boolean isMatchingLocation(String baseRoot, String domainRoot) {
+//        Path basePath = Paths.get(baseRoot, "glassfish").normalize();
+//        Path domainPath = Paths.get(domainRoot).getFileName();
+//        return basePath.equals(Paths.get(getPath(), "glassfish").normalize())
+//                && domainRoot.endsWith(getDomainName());
+//    }
+
+    public String getHost() {
+        return "localhost";
+    }
+
+    public int getHttpPort() {
+        if (portReader == null) {
+            portReader = createPortReader();
+        }
+        return portReader.getHttpPort();
+    }
+
+    public int getHttpsPort() {
+        if (portReader == null) {
+            portReader = createPortReader();
+        }
+        return portReader.getHttpsPort();
+    }
+
+    public int getAdminPort() {
+        if (portReader == null) {
+            portReader = createPortReader();
+        }
+        return portReader.getAdminPort();
+    }
+
+    private PortReader createPortReader() {
+        return new PortReader(getDomainXmlPath(), DAS_NAME);
+    }
+//
+//    public void checkAliveStatusUsingJPS(Runnable callback) throws IOException {
+//        String javaHome = getJDKHome();
+//        if (javaHome == null) {
+//            throw new IllegalStateException("Java home path not found.");
+//        }
+//
+//        String javaProcessExe = JavaUtils.javaProcessExecutableFullPath(javaHome);
+//        if (!Files.exists(Paths.get(javaProcessExe))) {
+//            throw new IllegalStateException("Java Process " + javaProcessExe + " executable for " + getName() + " was not found.");
+//        }
+//
+//        Process process = new ProcessBuilder(javaProcessExe, "-m", "-l", "-v").start();
+//        List<String> lines = Files.readAllLines(process.getInputStream().toPath());
+//        for (String line : lines) {
+//            String[] result = line.split(" ");
+//            if (result.length >= 6 && result[1].equals(ServerUtils.PF_MAIN_CLASS)
+//                    && result[3].equals(getDomainName()) && result[5].equals(getDomainPath())) {
+//                callback.run();
+//                break;
+//            }
+//        }
+//    }
+
+//    public void showLog() throws IOException {
+//        Files.readAllLines(Paths.get(getServerLog())).forEach(line -> getOutputChannel().appendLine(line));
+//    }
+
+//    public void connectOutput() throws IOException {
+//        if (logStream == null && Files.exists(Paths.get(getServerLog()))) {
+//            List<String> command = new ArrayList<>();
+//            if (JavaUtils.IS_WIN) {
+//                command.add("powershell.exe");
+//                command.add("Get-Content");
+//                command.add("-Tail");
+//                command.add("20");
+//                command.add("-Wait");
+//                command.add("-literalpath");
+//                command.add(getServerLog());
+//            } else {
+//                command.add("tail");
+//                command.add("-f");
+//                command.add("-n");
+//                command.add("20");
+//                command.add(getServerLog());
+//            }
+//
+//            logStream = new ProcessBuilder(command).start();
+//            logStream.getOutputStream().transferTo(getOutputChannel().getOutputStream());
+//        }
+//    }
+
+    public void disconnectOutput() {
+        if (logStream != null) {
+            logStream.destroy();
+        }
+    }
+
+  
+    
+}

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/ServerFetchProcessor.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/ServerFetchProcessor.java
@@ -1,0 +1,70 @@
+/*
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.maven.plugins.server;
+
+import org.apache.maven.plugin.MojoExecutionException;
+
+import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
+
+public class ServerFetchProcessor extends BaseProcessor {
+
+    private String payaraVersion;
+
+    @Override
+    public void handle(ExecutionEnvironment environment) throws MojoExecutionException {
+        executeMojo(dependencyPlugin,
+                goal("get"),
+                configuration(
+                        element("groupId", SERVER_GROUPID),
+                        element("artifactId", SERVER_ARTIFACTID),
+                        element("version", payaraVersion),
+                        element("packaging", "zip"),
+                        element("transitive", "false")
+                ),
+                environment
+        );
+
+        gotoNext(environment);
+    }
+
+    public ServerFetchProcessor set(String parameter) {
+        this.payaraVersion = parameter;
+        return this;
+    }
+}

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/ServerMojo.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/ServerMojo.java
@@ -1,0 +1,27 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package fish.payara.maven.plugins.server;
+
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.dependency.fromConfiguration.ArtifactItem;
+
+/**
+ *
+ * @author Gaurav Gupta
+ */
+public abstract class ServerMojo extends BasePayaraMojo {
+
+    @Parameter(property = "javaPath")
+    protected String javaPath;
+
+    @Parameter(property = "payaraVersion", defaultValue = "6.2024.12")
+    protected String payaraVersion;
+
+    @Parameter(property = "payaraServerAbsolutePath")
+    protected String payaraServerAbsolutePath;
+
+    @Parameter(property = "artifactItem")
+    protected ArtifactItem artifactItem;
+}

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/StartMojo.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/StartMojo.java
@@ -1,0 +1,556 @@
+/*
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.maven.plugins.server;
+
+import fish.payara.maven.plugins.server.parser.JDKVersion;
+import fish.payara.maven.plugins.server.parser.JvmOption;
+import fish.payara.maven.plugins.server.parser.JvmConfigReader;
+import fish.payara.maven.plugins.server.utils.JavaUtils;
+import fish.payara.maven.plugins.server.utils.ServerUtils;
+import fish.payara.maven.plugins.server.utils.StringUtils;
+import fish.payara.maven.plugins.AutoDeployHandler;
+import fish.payara.maven.plugins.PropertiesUtils;
+import fish.payara.maven.plugins.StartTask;
+import org.apache.commons.io.IOUtils;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.dependency.fromConfiguration.ArtifactItem;
+import org.apache.maven.toolchain.Toolchain;
+import org.twdata.maven.mojoexecutor.MojoExecutor;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static fish.payara.maven.plugins.server.Configuration.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import org.apache.maven.project.MavenProject;
+import org.openqa.selenium.WebDriver;
+
+/**
+ * Run mojo that executes payara-server
+ *
+ * @author Gaurav Gupta
+ */
+@Mojo(name = "start")
+public class StartMojo extends ServerMojo implements StartTask {
+
+    private static final String ERROR_MESSAGE = "Errors occurred while executing payara-server.";
+
+    @Parameter(property = "daemon", defaultValue = "false")
+    private boolean daemon;
+
+    @Parameter(property = "immediateExit", defaultValue = "false")
+    private boolean immediateExit;
+
+    /**
+     * Attach a debugger. If set to "true", the process will suspend and wait
+     * for a debugger to attach on port 5005. If set to other value, will be
+     * appended to the argLine, allowing you to configure custom debug options.
+     *
+     */
+    @Parameter(property = "debug", defaultValue = "false")
+    protected String debug;
+
+    @Parameter(property = "debugPort")
+    protected String debugPort;
+
+    private Process serverProcess;
+    private Thread serverProcessorThread;
+    private final ThreadGroup threadGroup;
+    private Toolchain toolchain;
+
+    private AutoDeployHandler autoDeployHandler;
+    private final List<String> rebootOnChange = new ArrayList<>();
+    private WebDriver driver;
+    private String payaraServerURL;
+
+    StartMojo() {
+        threadGroup = new ThreadGroup(SERVER_THREAD_NAME);
+    }
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        if (skip) {
+            getLog().info("Start mojo execution is skipped");
+            return;
+        }
+
+        toolchain = getToolchain();
+        final String path = decideOnWhichServerToUse();
+
+        serverProcessorThread = new Thread(threadGroup, () -> {
+
+            try {
+                ProcessBuilder processBuilder = startServer(new PayaraServerInstance("domain1", path));
+                getLog().info("Starting Payara Server [" + path + "] with the these arguments: " + processBuilder.command());
+                serverProcess = processBuilder.start();//re.exec(actualArgs.toArray(new String[0]));
+
+                if (daemon) {
+                    redirectStream(serverProcess.getInputStream(), System.out);
+                    redirectStream(serverProcess.getErrorStream(), System.err);
+                } else {
+                    redirectStreamToGivenOutputStream(serverProcess.getInputStream(), System.out);
+                    redirectStreamToGivenOutputStream(serverProcess.getErrorStream(), System.err);
+                }
+
+                int exitCode = serverProcess.waitFor();
+                if (exitCode != 0) { // && !autoDeploy
+                    throw new MojoFailureException(ERROR_MESSAGE);
+                }
+            } catch (InterruptedException ignored) {
+            } catch (Exception e) {
+                throw new RuntimeException(ERROR_MESSAGE, e);
+            } finally {
+                if (!daemon) {
+                    closeServerProcess();
+                }
+            }
+        });
+
+        if (daemon) {
+            serverProcessorThread.setDaemon(true);
+            serverProcessorThread.start();
+
+            if (!immediateExit) {
+                try {
+                    serverProcessorThread.join();
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+        } else {
+            Runtime.getRuntime().addShutdownHook(getShutdownHook());
+            serverProcessorThread.run();
+
+//            if (autoDeploy) {
+//                while (autoDeployHandler.isAlive()) {
+//                    serverProcessorThread.run();
+//                }
+//            }
+        }
+    }
+
+    public ProcessBuilder startServer(PayaraServerInstance payaraServer) throws Exception {
+        JvmConfigReader jvmConfigReader = new JvmConfigReader(payaraServer.getDomainXmlPath(), DAS_NAME);
+
+        String javaHome = payaraServer.getJDKHome();
+        if (javaHome == null) {
+            throw new Exception("Java home path not found.");
+        }
+
+        JDKVersion javaVersion = JDKVersion.getJDKVersion(javaHome);
+        if (javaVersion == null) {
+            throw new Exception("Java version not found.");
+        }
+
+        List<String> optList = new ArrayList<>();
+        for (JvmOption jvmOption : jvmConfigReader.getJvmOptions()) {
+            if (JDKVersion.isCorrectJDK(javaVersion, jvmOption.getVendor(), jvmOption.getMinVersion(), jvmOption.getMaxVersion())) {
+                optList.add(jvmOption.getOption());
+            }
+        }
+
+        Map<String, String> propMap = jvmConfigReader.getPropMap();
+        addJavaAgent(payaraServer, jvmConfigReader);
+
+        String bootstrapJar = Paths.get(payaraServer.getServerModules(), "glassfish.jar").toString();
+        if (!Files.exists(Paths.get(bootstrapJar))) {
+            throw new Exception("No bootstrap jar exists.");
+        }
+
+        String classPath = "";
+        String javaOpts;
+        String payaraArgs;
+
+        Map<String, String> varMap = varMap(payaraServer, javaHome);
+
+        String debugOpt = propMap.get("debug-options");
+        if (debug != null && !debug.equalsIgnoreCase("false") && debugOpt != null) {
+            if (Boolean.parseBoolean(debug)) {
+                if (isValidPort(debugPort)) {
+                    debugOpt = debugOpt.replaceAll("address=\\d+", "address=" + debugPort);
+                }
+                optList.add(debugOpt);
+            } else if (!"false".equals(debug)) {
+                optList.add(debug);
+            }
+            optList.add(debugOpt);
+        }
+
+        javaOpts = appendOptions(optList, varMap);
+        javaOpts += appendVarMap(varMap);
+        payaraArgs = appendPayaraArgs(getPayaraArgs(payaraServer));
+
+        String javaVmExe = JavaUtils.javaVmExecutableFullPath(javaHome);
+        if (!Files.exists(Paths.get(javaVmExe))) {
+            throw new Exception("Java VM executable for " + payaraServer.getPath() + " was not found.");
+        }
+
+        String allArgs = String.join(" ",
+                javaVmExe,
+                javaOpts,
+                "-jar", bootstrapJar,
+                "--classpath", classPath,
+                payaraArgs);
+        List<String> args = JavaUtils.parseParameters(allArgs);
+        ProcessBuilder processBuilder = new ProcessBuilder(args);
+        processBuilder.directory(new File(payaraServer.getPath()));
+        return processBuilder;
+    }
+
+    private boolean isValidPort(String portStr) {
+        if (portStr == null || portStr.trim().isEmpty()) {
+            return false;
+        }
+        try {
+            int port = Integer.parseInt(portStr.trim());
+            return port >= 0 && port <= 65535;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    private void addJavaAgent(PayaraServerInstance payaraServer, JvmConfigReader jvmConfigReader) throws Exception {
+        List<JvmOption> optList = jvmConfigReader.getJvmOptions();
+        String serverHome = payaraServer.getServerHome();
+
+        File monitor = Paths.get(serverHome, "lib", "monitor").toFile();
+        File btrace = Paths.get(monitor.getPath(), "btrace-agent.jar").toFile();
+        File flight = Paths.get(monitor.getPath(), "flashlight-agent.jar").toFile();
+
+        if (jvmConfigReader.isMonitoringEnabled()) {
+            if (btrace.exists()) {
+                optList.add(new JvmOption("-javaagent:" + StringUtils.quote(btrace.getPath()) + "=unsafe=true,noServer=true"));
+            } else if (flight.exists()) {
+                optList.add(new JvmOption("-javaagent:" + StringUtils.quote(flight.getPath())));
+            }
+        }
+    }
+
+    private Map<String, String> varMap(PayaraServerInstance payaraServer, String javaHome) {
+        Map<String, String> varMap = new HashMap<>();
+        varMap.put(ServerUtils.PF_HOME_PROPERTY, payaraServer.getServerHome());
+        varMap.put(ServerUtils.PF_DOMAIN_ROOT_PROPERTY, payaraServer.getDomainPath());
+        varMap.put(ServerUtils.PF_JAVA_ROOT_PROPERTY, javaHome);
+        varMap.put(JavaUtils.PATH_SEPARATOR, File.pathSeparator);
+        return varMap;
+    }
+
+    private String appendOptions(List<String> optList, Map<String, String> varMap) {
+        StringBuilder argumentBuf = new StringBuilder();
+        List<String> moduleOptions = new ArrayList<>();
+        Map<String, String> keyValueArgs = new HashMap<>();
+        List<String> keyOrder = new ArrayList<>();
+
+        for (String opt : optList) {
+            opt = StringUtils.doSub(opt.trim(), varMap);
+            int splitIndex = opt.indexOf('=');
+            String name, value = null;
+            if (splitIndex != -1 && !opt.startsWith("-agentpath:")) {
+                name = opt.substring(0, splitIndex);
+                value = StringUtils.quote(opt.substring(splitIndex + 1));
+            } else {
+                name = opt;
+            }
+
+            if (name.startsWith("--add-")) {
+                moduleOptions.add(opt);
+            } else {
+                if (!keyValueArgs.containsKey(name)) {
+                    keyOrder.add(name);
+                }
+                keyValueArgs.put(name, value);
+            }
+        }
+
+        argumentBuf.append(String.join(" ", moduleOptions));
+        for (String key : keyOrder) {
+            argumentBuf.append(" ").append(key);
+            if (keyValueArgs.get(key) != null) {
+                argumentBuf.append("=").append(keyValueArgs.get(key));
+            }
+        }
+        return argumentBuf.toString();
+    }
+
+    private String appendVarMap(Map<String, String> varMap) {
+        StringBuilder javaOpts = new StringBuilder();
+        varMap.forEach((key, value) -> javaOpts.append(" ").append(JavaUtils.systemProperty(key, value)));
+        return javaOpts.toString();
+    }
+
+    private List<String> getPayaraArgs(PayaraServerInstance payaraServer) {
+        List<String> payaraArgs = new ArrayList<>();
+        payaraArgs.add(ServerUtils.cmdLineArgument(ServerUtils.PF_DOMAIN_ARG, payaraServer.getDomainName()));
+        payaraArgs.add(ServerUtils.cmdLineArgument(ServerUtils.PF_DOMAIN_DIR_ARG, StringUtils.quote(payaraServer.getDomainPath())));
+        return payaraArgs;
+    }
+
+    private String appendPayaraArgs(List<String> payaraArgsList) {
+        return String.join(" ", payaraArgsList).trim();
+    }
+
+    private Thread getShutdownHook() {
+        return new Thread(threadGroup, () -> {
+            if (serverProcess != null && serverProcess.isAlive()) {
+                try {
+                    serverProcess.destroy();
+                    serverProcess.waitFor(1, TimeUnit.MINUTES);
+                } catch (InterruptedException ignored) {
+                } finally {
+                    serverProcess.destroyForcibly();
+                }
+            }
+        });
+    }
+
+    private String evaluateJavaPath() {
+        String javaToUse = JAVA_EXECUTABLE;
+
+        if (org.apache.commons.lang.StringUtils.isNotEmpty(javaPath)) {
+            javaToUse = javaPath;
+        } else if (toolchain != null) {
+            javaToUse = toolchain.findTool(JAVA_EXECUTABLE);
+        }
+        return javaToUse;
+    }
+
+    private String decideOnWhichServerToUse() throws MojoExecutionException {
+        if (payaraServerAbsolutePath != null) {
+            return payaraServerAbsolutePath;
+        }
+
+        if (artifactItem.getGroupId() != null) {
+            DefaultArtifact artifact = new DefaultArtifact(artifactItem.getGroupId(),
+                    artifactItem.getArtifactId(),
+                    artifactItem.getVersion(),
+                    null,
+                    artifactItem.getType(),
+                    artifactItem.getClassifier(),
+                    new DefaultArtifactHandler("zip"));
+            String targetDir = getBaseDir() + File.separator + "payara-server-" + payaraVersion;
+            // Check if the target directory already exists
+            File extractedDir = new File(targetDir + File.separator + "payara" + artifactItem.getVersion().charAt(0));
+            if (!extractedDir.exists()) {
+                try {
+                    extractZipFile(findLocalPathOfArtifact(artifact), targetDir);
+                } catch (IOException e) {
+                    throw new MojoExecutionException("Failed to extract Payara Server zip file", e);
+                }
+            }
+
+            return extractedDir.getAbsolutePath();
+        }
+
+        if (payaraVersion != null) {
+            MojoExecutor.ExecutionEnvironment environment = getEnvironment();
+            ServerFetchProcessor serverFetchProcessor = new ServerFetchProcessor();
+            serverFetchProcessor.set(payaraVersion).handle(environment);
+
+            // after downloading extract the zip
+            DefaultArtifact artifact = new DefaultArtifact(SERVER_GROUPID, SERVER_ARTIFACTID,
+                    payaraVersion,
+                    null,
+                    "zip",
+                    null,
+                    new DefaultArtifactHandler("zip"));
+            String targetDir = getBaseDir() + File.separator + "payara-server-" + payaraVersion;
+            // Check if the target directory already exists
+            File extractedDir = new File(targetDir + File.separator + "payara" + payaraVersion.charAt(0));
+            if (!extractedDir.exists()) {
+                try {
+                    extractZipFile(findLocalPathOfArtifact(artifact), targetDir);
+                } catch (IOException e) {
+                    throw new MojoExecutionException("Failed to extract Payara Server zip file", e);
+                }
+            }
+
+            return extractedDir.getAbsolutePath();
+        }
+
+        throw new MojoExecutionException("Could not determine Payara Server path. Please set it by defining either \"useUberJar\", \"payaraServerAbsolutePath\" or \"artifactItem\" configuration options.");
+    }
+
+    private String findLocalPathOfArtifact(DefaultArtifact artifact) {
+        Artifact payaraServerArtifact = mavenSession.getLocalRepository().find(artifact);
+        return payaraServerArtifact.getFile().getAbsolutePath();
+    }
+
+    private void extractZipFile(String zipFilePath, String destDir) throws IOException {
+        File dir = new File(destDir);
+        if (!dir.exists()) {
+            dir.mkdirs(); // Create destination directory if it doesn't exist
+        }
+
+        try (ZipInputStream zipIn = new ZipInputStream(new FileInputStream(zipFilePath))) {
+            ZipEntry entry;
+            while ((entry = zipIn.getNextEntry()) != null) {
+                String filePath = destDir + File.separator + entry.getName();
+                if (!entry.isDirectory()) {
+                    // If the entry is a file, extract it
+                    extractFile(zipIn, filePath);
+                } else {
+                    // If the entry is a directory, create it
+                    File dirEntry = new File(filePath);
+                    dirEntry.mkdirs();
+                }
+                zipIn.closeEntry();
+            }
+        }
+    }
+
+    private void extractFile(ZipInputStream zipIn, String filePath) throws IOException {
+        try (FileOutputStream fos = new FileOutputStream(filePath)) {
+            byte[] buffer = new byte[1024];
+            int len;
+            while ((len = zipIn.read(buffer)) != -1) {
+                fos.write(buffer, 0, len);
+            }
+        }
+    }
+
+    protected String getBaseDir() {
+        return mavenProject.getBuild().getDirectory();
+    }
+
+    private String evaluateProjectArtifactAbsolutePath(String extension) {
+        String projectJarAbsolutePath = getBaseDir() + File.separator;
+        projectJarAbsolutePath += evaluateExecutorName(extension);
+        return projectJarAbsolutePath;
+    }
+
+    private String evaluateExecutorName(String extension) {
+        if (org.apache.commons.lang.StringUtils.isNotEmpty(mavenProject.getBuild().getFinalName())) {
+            return mavenProject.getBuild().getFinalName() + extension;
+        }
+        return mavenProject.getArtifactId() + '-' + mavenProject.getVersion() + extension;
+    }
+
+    void closeServerProcess() {
+        if (serverProcess != null) {
+            try {
+                serverProcess.exitValue();
+            } catch (IllegalThreadStateException e) {
+                serverProcess.destroy();
+                getLog().info("Terminated payara-server.");
+            }
+        }
+    }
+
+    Process getServerProcess() {
+        return this.serverProcess;
+    }
+
+    private void redirectStream(final InputStream inputStream, final PrintStream printStream) {
+        final Thread thread = new Thread(threadGroup, () -> {
+            BufferedReader br;
+            StringBuilder sb = new StringBuilder();
+
+            String line;
+            try {
+                br = new BufferedReader(new InputStreamReader(inputStream));
+                while ((line = br.readLine()) != null) {
+                    sb.append(line);
+                    printStream.println(line);
+                    if (!immediateExit && sb.toString().contains(SERVER_READY_MESSAGE)) {
+                        serverProcessorThread.interrupt();
+                        br.close();
+                        break;
+                    }
+                }
+            } catch (IOException e) {
+                getLog().error(ERROR_MESSAGE, e);
+            }
+        });
+        thread.setDaemon(false);
+        thread.start();
+    }
+
+    private void redirectStreamToGivenOutputStream(final InputStream inputStream, final OutputStream outputStream) {
+        Thread thread = new Thread(threadGroup, () -> {
+            try {
+                if (outputStream instanceof PrintStream) {
+                    String line;
+                    BufferedReader br = new BufferedReader(new InputStreamReader(inputStream));
+                    PrintStream printStream = (PrintStream) outputStream;
+
+                    while ((line = br.readLine()) != null) {
+                        printStream.println(line);
+                    }
+                } else {
+                    IOUtils.copy(inputStream, outputStream);
+                }
+            } catch (IOException e) {
+                getLog().error("Error occurred while reading stream", e);
+            }
+        });
+        thread.setDaemon(false);
+        thread.start();
+    }
+
+    @Override
+    public MavenProject getProject() {
+        return this.getEnvironment().getMavenProject();
+    }
+
+    @Override
+    public List<String> getRebootOnChange() {
+        return rebootOnChange;
+    }
+
+    public WebDriver getDriver() {
+        return null;
+    }
+
+    public boolean isLocal() {
+        return true;
+    }
+}

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/parser/JDKVersion.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/parser/JDKVersion.java
@@ -1,0 +1,264 @@
+/*
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.maven.plugins.server.parser;
+
+import fish.payara.maven.plugins.server.utils.JavaUtils;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class JDKVersion {
+
+    private int major;
+    private Integer minor;
+    private Integer subminor;
+    private Integer update;
+    private String vendor;
+
+    private static final int MAJOR_INDEX = 0;
+    private static final int MINOR_INDEX = 1;
+    private static final int SUBMINOR_INDEX = 2;
+    private static final int UPDATE_INDEX = 3;
+    private static final int DEFAULT_VALUE = 0;
+    private static final String VERSION_MATCHER = "(\\d+(\\.\\d+)*)([_u\\-]+[\\S]+)*";
+
+    public JDKVersion(int major, Integer minor, Integer subminor, Integer update, String vendor) {
+        this.major = major;
+        this.minor = minor;
+        this.subminor = subminor;
+        this.update = update;
+        this.vendor = vendor;
+    }
+
+    // Getters
+    public int getMajor() {
+        return major;
+    }
+
+    public Integer getMinor() {
+        return minor;
+    }
+
+    public Integer getSubMinor() {
+        return subminor;
+    }
+
+    public Integer getUpdate() {
+        return update;
+    }
+
+    public String getVendor() {
+        return vendor;
+    }
+
+    public boolean gt(JDKVersion version) {
+        if (this.major > version.getMajor()) {
+            return true;
+        } else if (this.major == version.getMajor()) {
+            if (gtNumber(this.minor, version.getMinor())) {
+                return true;
+            } else if (eq(this.minor, version.getMinor())) {
+                if (gtNumber(this.subminor, version.getSubMinor())) {
+                    return true;
+                } else if (eq(this.subminor, version.getSubMinor())) {
+                    return gtNumber(this.update, version.getUpdate());
+                }
+            }
+        }
+        return false;
+    }
+
+    public boolean lt(JDKVersion version) {
+        if (this.major < version.getMajor()) {
+            return true;
+        } else if (this.major == version.getMajor()) {
+            if (ltNumber(this.minor, version.getMinor())) {
+                return true;
+            } else if (eq(this.minor, version.getMinor())) {
+                if (ltNumber(this.subminor, version.getSubMinor())) {
+                    return true;
+                } else if (eq(this.subminor, version.getSubMinor())) {
+                    return ltNumber(this.update, version.getUpdate());
+                }
+            }
+        }
+        return false;
+    }
+
+    public boolean ge(JDKVersion version) {
+        return this.gt(version) || this.equals(version);
+    }
+
+    public boolean le(JDKVersion version) {
+        return this.lt(version) || this.equals(version);
+    }
+
+    private boolean gtNumber(Integer v1, Integer v2) {
+        if (v1 == null) v1 = DEFAULT_VALUE;
+        if (v2 == null) v2 = DEFAULT_VALUE;
+        return v1 > v2;
+    }
+
+    private boolean ltNumber(Integer v1, Integer v2) {
+        if (v1 == null) v1 = DEFAULT_VALUE;
+        if (v2 == null) v2 = DEFAULT_VALUE;
+        return v1 < v2;
+    }
+
+    private boolean eq(Integer v1, Integer v2) {
+        if (v1 == null) v1 = DEFAULT_VALUE;
+        if (v2 == null) v2 = DEFAULT_VALUE;
+        return v1.equals(v2);
+    }
+
+    public boolean equals(JDKVersion other) {
+        if (other == null) return false;
+        return this.major == other.getMajor() &&
+               eq(this.minor, other.getMinor()) &&
+               eq(this.subminor, other.getSubMinor()) &&
+               eq(this.update, other.getUpdate());
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder value = new StringBuilder(Integer.toString(major));
+        if (minor != null) value.append(minor);
+        if (subminor != null) value.append(subminor);
+        if (update != null) value.append(update);
+        return value.toString();
+    }
+
+    public static JDKVersion toValue(String version, String vendor) {
+        if (version != null && !version.isEmpty()) {
+            int[] versions = parseVersions(version);
+            int major = versions[MAJOR_INDEX];
+            Integer minor = versions[MINOR_INDEX];
+            Integer subminor = versions[SUBMINOR_INDEX];
+            Integer update = versions[UPDATE_INDEX];
+            return new JDKVersion(major, minor, subminor, update, vendor);
+        }
+        return null;
+    }
+
+    public static int[] parseVersions(String javaVersion) {
+        int[] versions = {1, 0, 0, 0};
+        if (javaVersion != null && !javaVersion.isEmpty()) {
+            String[] javaVersionSplit = javaVersion.split("-");
+            String[] split = javaVersionSplit[0].split("\\.");
+            if (split.length > 0) {
+                versions[MAJOR_INDEX] = Integer.parseInt(split[0]);
+                if (split.length > 1) versions[MINOR_INDEX] = Integer.parseInt(split[1]);
+                if (split.length > 2) {
+                    String[] subSplit = split[2].split("[_u]+");
+                    versions[SUBMINOR_INDEX] = Integer.parseInt(subSplit[0]);
+                    if (subSplit.length > 1) versions[UPDATE_INDEX] = Integer.parseInt(subSplit[1]);
+                }
+            }
+        }
+        return versions;
+    }
+
+    // Example method to get default JDK path (similar to original JavaScript functionality)
+    public static String getDefaultJDKHome() {
+        String javaHome = System.getenv("JDK_HOME");
+        if (javaHome == null) {
+            javaHome = System.getenv("JAVA_HOME");
+        }
+        return javaHome;
+    }
+
+    public static JDKVersion getJDKVersion(String javaHome) throws IOException {
+        String javaVersion = "";
+        String implementor = null;
+
+        String javaVmExe = JavaUtils.javaVmExecutableFullPath(javaHome);
+        // Check if the Java executable exists.
+        if (!new File(javaVmExe).exists()) {
+            throw new IOException("Java VM executable not found at: " + javaVmExe);
+        }
+
+        // Run the command to get Java properties and version.
+        Process process = new ProcessBuilder(javaVmExe, "-XshowSettings:properties", "-version")
+                .redirectErrorStream(true)
+                .start();
+
+        BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+        String line;
+        while ((line = reader.readLine()) != null) {
+            if (line.contains("java.version =")) {
+                javaVersion = extractValue(line);
+            } else if (line.contains("java.vendor =")) {
+                implementor = extractValue(line);
+            }
+        }
+
+        reader.close();
+
+        if (!javaVersion.isEmpty()) {
+            return JDKVersion.toValue(javaVersion, implementor);
+        }
+
+        return null;
+    }
+    
+     private static String extractValue(String line) {
+        String[] keyValue = line.split("=");
+        if (keyValue.length == 2) {
+            return keyValue[1].trim();
+        }
+        return "";
+    }
+    public static boolean isCorrectJDK(JDKVersion jdkVersion, String vendor, JDKVersion minVersion, JDKVersion maxVersion) {
+        boolean correctJDK = true;
+        if (vendor != null) {
+            String jdkVendor = jdkVersion.getVendor();
+            if (jdkVendor != null && !jdkVendor.contains(vendor)) {
+                correctJDK = false;
+            }
+        }
+        if (correctJDK && minVersion != null) {
+            correctJDK = jdkVersion.ge(minVersion);
+        }
+        if (correctJDK && maxVersion != null) {
+            correctJDK = jdkVersion.le(maxVersion);
+        }
+        return correctJDK;
+    }
+}

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/parser/JvmConfigReader.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/parser/JvmConfigReader.java
@@ -1,0 +1,135 @@
+/*
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.maven.plugins.server.parser;
+
+import org.w3c.dom.*;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class JvmConfigReader {
+
+    private final String serverName;
+    private final List<JvmOption> jvmOptions = new ArrayList<>();
+    private final Map<String, String> propMap = new HashMap<>();
+    private boolean monitoringEnabled = false;
+    private String serverConfigName = "";
+    private boolean readConfig = false;
+
+    public JvmConfigReader(String domainXmlPath, String serverName) {
+        this.serverName = serverName;
+        parseDomainXML(domainXmlPath);
+    }
+
+    private void parseDomainXML(String domainXmlPath) {
+        try {
+            File xmlFile = new File(domainXmlPath);
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            Document doc = builder.parse(xmlFile);
+            doc.getDocumentElement().normalize();
+
+            NodeList servers = doc.getElementsByTagName("server");
+            NodeList configs = doc.getElementsByTagName("config");
+
+            // Find the server with the matching name
+            for (int i = 0; i < servers.getLength(); i++) {
+                Node serverNode = servers.item(i);
+                if (serverNode.getNodeType() == Node.ELEMENT_NODE) {
+                    Element serverElement = (Element) serverNode;
+                    if (serverName.equals(serverElement.getAttribute("name"))) {
+                        serverConfigName = serverElement.getAttribute("config-ref");
+                        break;
+                    }
+                }
+            }
+
+            // Find the config with the matching name
+            for (int i = 0; i < configs.getLength(); i++) {
+                Node configNode = configs.item(i);
+                if (configNode.getNodeType() == Node.ELEMENT_NODE) {
+                    Element configElement = (Element) configNode;
+                    if (serverConfigName.equals(configElement.getAttribute("name"))) {
+                        NodeList javaConfigList = configElement.getElementsByTagName("java-config");
+                        if (javaConfigList.getLength() > 0) {
+                            Element javaConfig = (Element) javaConfigList.item(0);
+
+                            // Parse jvm-options
+                            NodeList jvmOptionsList = javaConfig.getElementsByTagName("jvm-options");
+                            for (int j = 0; j < jvmOptionsList.getLength(); j++) {
+                                Node jvmOptionNode = jvmOptionsList.item(j);
+                                if (jvmOptionNode.getNodeType() == Node.ELEMENT_NODE) {
+                                    String value = jvmOptionNode.getTextContent().trim();
+                                    jvmOptions.add(new JvmOption(value));
+                                }
+                            }
+
+                            // Parse attributes into propMap
+                            NamedNodeMap attributes = javaConfig.getAttributes();
+                            for (int k = 0; k < attributes.getLength(); k++) {
+                                Node attribute = attributes.item(k);
+                                propMap.put(attribute.getNodeName(), attribute.getNodeValue());
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to parse file " + domainXmlPath + " : " + e.getMessage(), e);
+        }
+    }
+
+    public List<JvmOption> getJvmOptions() {
+        return jvmOptions;
+    }
+
+    public Map<String, String> getPropMap() {
+        return propMap;
+    }
+
+    public boolean isMonitoringEnabled() {
+        return monitoringEnabled;
+    }
+
+}

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/parser/JvmOption.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/parser/JvmOption.java
@@ -1,0 +1,99 @@
+/*
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.maven.plugins.server.parser;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class JvmOption {
+
+    private static final String PATTERN = "^\\[(.*)\\|(.*)\\](.*)";
+    private String option;
+    private String vendor;
+    private JDKVersion minVersion;
+    private JDKVersion maxVersion;
+
+    public JvmOption(String option) {
+        Pattern pattern = Pattern.compile(PATTERN);
+        Matcher matcher = pattern.matcher(option);
+
+        if (matcher.matches() && matcher.groupCount() == 3) {
+            // [Azul-1.8.0|1.8.0u120]-Xbootclasspath
+            String vendorString = matcher.group(1);
+            if (vendorString.contains("-") && vendorString.matches(".*[a-zA-Z].*")) {
+                String[] parts = vendorString.split("-");
+                this.vendor = parts[0];
+                this.minVersion = JDKVersion.toValue(parts[1], null);
+            } else {
+                this.vendor = null;
+                this.minVersion = JDKVersion.toValue(vendorString, null);
+            }
+            this.maxVersion = JDKVersion.toValue(matcher.group(2), null);
+            this.option = matcher.group(3);
+        } else {
+            this.option = option;
+        }
+    }
+
+    public String getOption() {
+        return option;
+    }
+
+    public String getVendor() {
+        return vendor;
+    }
+
+    public JDKVersion getMinVersion() {
+        return minVersion;
+    }
+
+    public JDKVersion getMaxVersion() {
+        return maxVersion;
+    }
+
+    @Override
+    public String toString() {
+        return "JvmOption{" +
+                "option='" + option + '\'' +
+                ", vendor='" + vendor + '\'' +
+                ", minVersion=" + minVersion +
+                ", maxVersion=" + maxVersion +
+                '}';
+    }
+}

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/parser/PortReader.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/parser/PortReader.java
@@ -1,0 +1,141 @@
+/*
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.maven.plugins.server.parser;
+
+import java.io.File;
+import java.io.IOException;
+import org.xml.sax.SAXException;
+import org.w3c.dom.*;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+public class PortReader {
+
+    private String serverName;
+    private int httpPort = -1;
+    private int httpsPort = -1;
+    private int adminPort = -1;
+    private String serverConfigName = "";
+
+    public PortReader(String domainXmlPath, String serverName) {
+        this.serverName = serverName;
+        parseDomainXML(domainXmlPath);
+    }
+
+    private void parseDomainXML(String domainXmlPath) {
+        try {
+            File file = new File(domainXmlPath);
+            
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            Document document = builder.parse(file);
+            
+            // Normalize the XML structure
+            document.getDocumentElement().normalize();
+            
+            NodeList servers = document.getElementsByTagName("server");
+            NodeList configs = document.getElementsByTagName("config");
+            
+            // Iterate over servers
+            for (int i = 0; i < servers.getLength(); i++) {
+                Node serverNode = servers.item(i);
+                if (serverNode.getNodeType() == Node.ELEMENT_NODE) {
+                    Element serverElement = (Element) serverNode;
+                    String name = serverElement.getAttribute("name");
+                    if (name.equals(serverName)) {
+                        serverConfigName = serverElement.getAttribute("config-ref");
+                    }
+                }
+            }
+            
+            // Iterate over configs
+            for (int i = 0; i < configs.getLength(); i++) {
+                Node configNode = configs.item(i);
+                if (configNode.getNodeType() == Node.ELEMENT_NODE) {
+                    Element configElement = (Element) configNode;
+                    String configName = configElement.getAttribute("name");
+                    if (configName.equals(serverConfigName)) {
+                        NodeList networkListeners = configElement.getElementsByTagName("network-listener");
+                        for (int j = 0; j < networkListeners.getLength(); j++) {
+                            Node networkListenerNode = networkListeners.item(j);
+                            if (networkListenerNode.getNodeType() == Node.ELEMENT_NODE) {
+                                Element networkListenerElement = (Element) networkListenerNode;
+                                String name = networkListenerElement.getAttribute("name");
+                                int port = Integer.parseInt(networkListenerElement.getAttribute("port"));
+                                if (name.equals("http-listener-1")) {
+                                    httpPort = port;
+                                } else if (name.equals("http-listener-2")) {
+                                    httpsPort = port;
+                                } else if (name.equals("admin-listener")) {
+                                    adminPort = port;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (IOException | NumberFormatException | ParserConfigurationException | SAXException ex) {
+            throw new IllegalStateException("Unable to parse domain.xml: " + ex.getMessage());
+        }
+    }
+
+    public int getHttpPort() {
+        return httpPort;
+    }
+
+    public int getHttpsPort() {
+        return httpsPort;
+    }
+
+    public int getAdminPort() {
+        return adminPort;
+    }
+
+    public static void main(String[] args) {
+        try {
+            PortReader reader = new PortReader("path/to/domain.xml", "server-name");
+            System.out.println("HTTP Port: " + reader.getHttpPort());
+            System.out.println("HTTPS Port: " + reader.getHttpsPort());
+            System.out.println("Admin Port: " + reader.getAdminPort());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/utils/JavaUtils.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/utils/JavaUtils.java
@@ -1,0 +1,281 @@
+/*
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.maven.plugins.server.utils;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+public class JavaUtils {
+
+    /** Java executables directory under Java home. */
+    private static final String JAVA_BIN_DIR = "bin";
+
+    /** Java VM executable file name (without path). */
+    private static final String JAVA_VM_EXE = "java";
+
+    /** Java Process file name (without path). */
+    private static final String JAVA_PROCESS_EXE = "jps";
+
+    /** Java SE JDK class path option. */
+    public static final String VM_CLASSPATH_OPTION = "-cp";
+
+    /** Java VM system property option. */
+    private static final String VM_SYS_PROP_OPT = "-D";
+
+    /** Java VM system property quoting character. */
+    private static final String VM_SYS_PROP_QUOTE = "\"";
+
+    /** Java VM system property assignment. */
+    private static final String VM_SYS_PROP_ASSIGN = "=";
+
+    public static final String PATH_SEPARATOR = System.getProperty("path.separator");
+
+    public static final boolean IS_WIN = System.getProperty("os.name").toLowerCase().contains("win");
+
+    /**
+     * Append quoted Java VM system property
+     * <code>-D"&lt;name&gt;=&lt;value&gt;"</code> into a StringBuilder.
+     * 
+     * @param name  Java VM system property name.
+     * @param value Java VM system property value.
+     * @return formatted system property string.
+     */
+    public static String systemProperty(String name, String value) {
+        return VM_SYS_PROP_OPT + VM_SYS_PROP_QUOTE + name + VM_SYS_PROP_ASSIGN + value + VM_SYS_PROP_QUOTE;
+    }
+
+    /**
+     * Build Java VM executable full path from Java Home directory.
+     * 
+     * @param javaHome Full path to Java Home directory.
+     * @return Java VM executable full path.
+     */
+    public static String javaVmExecutableFullPath(String javaHome) {
+        return javaExecutableFullPath(javaHome, JAVA_VM_EXE);
+    }
+
+    /**
+     * Build Java Process executable full path from Java Home directory.
+     * 
+     * @param javaHome Full path to Java Home directory.
+     * @return Java Process executable full path.
+     */
+    public static String javaProcessExecutableFullPath(String javaHome) {
+        return javaExecutableFullPath(javaHome, JAVA_PROCESS_EXE);
+    }
+
+    private static String javaExecutableFullPath(String javaHome, String type) {
+        Path javaHomePath = Paths.get(javaHome);
+        String javaExecStr = javaHomePath.toString();
+
+        if (!javaExecStr.endsWith(System.getProperty("file.separator"))) {
+            javaExecStr += System.getProperty("file.separator");
+        }
+
+        javaExecStr += JAVA_BIN_DIR + System.getProperty("file.separator") + type;
+
+        if (IS_WIN) {
+            javaExecStr += ".exe";
+        }
+
+        return javaExecStr;
+    }
+
+
+    /**
+     * Parses parameters from a given string in a shell-like manner and appends
+     * them to the executable file.
+     * 
+     * Users of the Bourne shell (e.g., on Unix) will already be familiar with
+     * the behavior. For example, you should be able to:
+     * Include command names with embedded spaces, such as
+     * <code>c:\Program Files\jdk\bin\javac</code>.
+     * Include extra command arguments, such as <code>-Dname=value</code>.
+     * Do anything else which might require unusual characters
+     * or processing. For example:
+     * <code>
+     * "c:\program files\jdk\bin\java" -Dmessage="Hello /\\/\\ there!" -Xmx128m
+     * </code>
+     * 
+     * This example would create the following executable name and
+     * arguments:
+     * 
+     * <code>c:\program files\jdk\bin\java</code>
+     * <code>-Dmessage=Hello /\/\ there!</code>
+     * <code>-Xmx128m</code>
+     * 
+     * Note that the command string does not escape its backslashes--under
+     * the assumption that Windows users will not think to do this, meaningless
+     * escapes are just left as backslashes plus the following character.
+     * 
+     * Caveat: even after parsing, Windows programs (such as the
+     * Java launcher) may not fully honor certain characters, such as quotes,
+     * in command names or arguments. This is because programs under Windows
+     * frequently perform their own parsing and unescaping (since the shell
+     * cannot be relied on to do this). On Unix, this problem should not occur.
+     * @param args A string to parse.
+     * @return A list of executable file and parameters to be passed to it.
+     */
+    public static List<String> parseParameters(String args) {
+        int NULL = 0;
+        int INPARAM = 1;
+        int INPARAMPENDING = 2;
+        int STICK = 4;
+        int STICKPENDING = 8;
+
+        List<String> params = new ArrayList<>();
+        StringBuilder buff = new StringBuilder();
+        int state = NULL;
+        int slength = args.length();
+
+        for (int i = 0; i < slength; i++) {
+            char c = args.charAt(i);
+            if (Character.isWhitespace(c)) { // check for whitespace
+                if (state == NULL) {
+                    if (buff.length() > 0) {
+                        params.add(buff.toString());
+                        buff.setLength(0);  // reset buffer
+                    }
+                } else if (state == STICK) {
+                    params.add(buff.toString());
+                    buff.setLength(0);  // reset buffer
+                    state = NULL;
+                } else if (state == STICKPENDING) {
+                    buff.append('\\');
+                    params.add(buff.toString());
+                    buff.setLength(0);  // reset buffer
+                    state = NULL;
+                } else if (state == INPARAMPENDING) {
+                    state = INPARAM;
+                    buff.append('\\').append(c);
+                } else { // INPARAM
+                    buff.append(c);
+                }
+                continue;
+            }
+
+            if (c == '\\') {
+                if (state == NULL) {
+                    ++i;
+                    if (i < slength) {
+                        char cc = args.charAt(i);
+                        if (cc == '\"' || cc == '\\') {
+                            buff.append(cc);
+                        } else if (Character.isWhitespace(cc)) { // check whitespace
+                            buff.append(c);
+                            --i;
+                        } else {
+                            buff.append(c).append(cc);
+                        }
+                    } else {
+                        buff.append('\\');
+                        break;
+                    }
+                    continue;
+                } else if (state == INPARAM) {
+                    state = INPARAMPENDING;
+                } else if (state == INPARAMPENDING) {
+                    buff.append('\\');
+                    state = INPARAM;
+                } else if (state == STICK) {
+                    state = STICKPENDING;
+                } else if (state == STICKPENDING) {
+                    buff.append('\\');
+                    state = STICK;
+                }
+                continue;
+            }
+
+            if (c == '\"') {
+                if (state == NULL) {
+                    state = INPARAM;
+                } else if (state == INPARAM) {
+                    state = STICK;
+                } else if (state == STICK) {
+                    state = INPARAM;
+                } else if (state == STICKPENDING) {
+                    buff.append('\"');
+                    state = STICK;
+                } else { // INPARAMPENDING
+                    buff.append('\"');
+                    state = INPARAM;
+                }
+                continue;
+            }
+
+            if (state == INPARAMPENDING) {
+                buff.append('\\');
+                state = INPARAM;
+            } else if (state == STICKPENDING) {
+                buff.append('\\');
+                state = STICK;
+            }
+            buff.append(c);
+        }
+
+        // Collect remaining parameter
+        if (state == INPARAM) {
+            params.add(buff.toString());
+        } else if ((state & (INPARAMPENDING | STICKPENDING)) != 0) {
+            buff.append('\\');
+            params.add(buff.toString());
+        } else {
+            if (buff.length() > 0) {
+                params.add(buff.toString());
+            }
+        }
+
+        return params;
+    }
+    public static void main(String[] args) {
+        // Test the methods
+        String javaHome = "/path/to/java/home";
+        System.out.println("Java VM Full Path: " + javaVmExecutableFullPath(javaHome));
+        System.out.println("Java Process Full Path: " + javaProcessExecutableFullPath(javaHome));
+        System.out.println("System Property: " + systemProperty("my.property", "value"));
+        
+        String commandLineArgs = "\"C:\\Program Files\\Java\\jdk1.8.0_171\\bin\\java\" -Dproperty=value -Xmx128m";
+        List<String> parsedArgs = parseParameters(commandLineArgs);
+        for (String arg : parsedArgs) {
+            System.out.println("Parsed Arg: " + arg);
+        }
+    }
+}

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/utils/ServerUtils.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/utils/ServerUtils.java
@@ -1,0 +1,129 @@
+/*
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.maven.plugins.server.utils;
+
+import java.io.File;
+
+public class ServerUtils {
+
+    /** 
+     * Payara server Java VM root property name.
+     */
+    public static final String PF_JAVA_ROOT_PROPERTY = "com.sun.aas.javaRoot";
+
+    /** 
+     * Payara server home property name.
+     *
+     * It's value says it is server installation root but in reality it is just
+     * <code>payara</code> subdirectory under server installation root which
+     * we usually call server home.
+     */
+    public static final String PF_HOME_PROPERTY = "com.sun.aas.installRoot";
+
+    /** 
+     * Payara server domain root property name.
+     *
+     * It's value says it is server instance root which is the same. 
+     */
+    public static final String PF_DOMAIN_ROOT_PROPERTY = "com.sun.aas.instanceRoot";
+
+    /** 
+     * Payara server Derby root property name.
+     */
+    public static final String PF_DERBY_ROOT_PROPERTY = "com.sun.aas.derbyRoot";
+
+    /** 
+     * Payara server domain name command line argument.
+     */
+    public static final String PF_DOMAIN_ARG = "--domain";
+    
+    
+    public static final String ASADMIN = "asadmin";
+    public static final String STOP_DOMAIN = "stop-domain";
+
+    /** 
+     * Payara server domain directory command line argument.
+     */
+    public static final String PF_DOMAIN_DIR_ARG = "--domaindir";
+
+    /** Payara main class to be started when using classpath. */
+    public static final String PF_MAIN_CLASS = "com.sun.enterprise.glassfish.bootstrap.ASMain";
+
+    public static final String DEFAULT_USERNAME = "admin";
+    public static final String DEFAULT_PASSWORD = "";
+    public static final String MASTER_PASSWORD = "changeit";
+    public static final int DEFAULT_ADMIN_PORT = 4848;
+    public static final int DEFAULT_HTTP_PORT = 8080;
+    public static final String DEFAULT_HOST = "localhost";
+
+    /** Default name of the DAS server. */
+    public static final String DAS_NAME = "server";
+
+    /** Default retry count to check alive status of server. */
+    public static final int DEFAULT_RETRY_COUNT = 30;
+
+    /** Default sleep time in millisecond before retry to check alive status of server. */
+    public static final int DEFAULT_WAIT = 3000;
+
+    /**
+     * Builds command line argument containing argument identifier, space
+     * and argument value, e.g. <code>--name value</code>.
+     *
+     * @param name      Command line argument name including dashes at
+     *                  the beginning.
+     * @param value     Value to be appended prefixed with single space.
+     * @return Command line argument concatenated together.
+     */
+    public static String cmdLineArgument(String name, String value) {
+        return name + " " + value;
+    }
+
+    /**
+     * Checks if the provided server path is valid by ensuring the existence of
+     * the necessary Payara server files.
+     *
+     * @param serverPath Path to the server directory.
+     * @return True if the server path is valid, otherwise false.
+     */
+    public static boolean isValidServerPath(String serverPath) {
+        File asadminInGlassfish = new File(serverPath + "/glassfish/bin/asadmin");
+        File asadminInBin = new File(serverPath + "/bin/asadmin");
+        return asadminInGlassfish.exists() && asadminInBin.exists();
+    }
+}

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/utils/StringUtils.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/utils/StringUtils.java
@@ -1,0 +1,95 @@
+/*
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.maven.plugins.server.utils;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class StringUtils {
+
+    private static final String PATTERN = "\\$\\{([^}]+)\\}";
+
+    /**
+     * Add quotes to string if and only if it contains space characters.
+     *
+     * Note: does not handle generalized white space (tabs, localized white
+     * space, etc.)
+     *
+     * @param path File path in string form.
+     * @return Quoted path if it contains any space characters, otherwise same.
+     */
+    public static String quote(String path) {
+        return path.indexOf(' ') == -1 ? path : "\"" + path + "\"";
+    }
+
+    /**
+     * Utility method that finds all occurrences of variable references and
+     * replaces them with their values.
+     * Values are taken from <code>varMap</code> and escaped. If they are
+     * not present there, system properties are queried. If not found there
+     * the variable reference is replaced with the same string with special
+     * characters escaped.
+     * 
+     * @param input String value where the variables have to be replaced with values
+     * @param varMap mapping of variable names to their values
+     * @return String where the all the replacement was done
+     */
+    public static String doSub(String input, Map<String, String> varMap) {
+        Pattern pattern = Pattern.compile(PATTERN);
+        Matcher matcher = pattern.matcher(input);
+        while (matcher.find()) {
+            String varName = matcher.group(1);
+            String replacement = varMap.getOrDefault(varName, System.getProperty(varName, ""));
+            input = input.replace("${" + varName + "}", escapePath(replacement));
+        }
+        return input;
+    }
+
+    /**
+     * Add escape characters for backslash and dollar sign characters in
+     * path field.
+     *
+     * @param path file path in string form.
+     * @return adjusted path with backslashes and dollar signs escaped with
+     *   backslash character.
+     */
+    public static String escapePath(String path) {
+        return path.replace("\\", "\\\\").replace("$", "\\$");
+    }
+}


### PR DESCRIPTION
This PR adds the capability to start and stop a local Payara Server instance using the **Payara Server Maven Plugin**. It simplifies the server lifecycle management by enabling developers to control the server directly through Maven commands.

## Key Changes
  - `payara-server:start` - Starts the local Payara Server.
  - Ctrl + C to stop the running Payara Server.

## Usage
Add the following plugin configuration to your project's pom.xml file:
```
<build>
    <plugins>
        <plugin>
            <groupId>fish.payara.maven.plugins</groupId>
            <artifactId>payara-server-maven-plugin</artifactId>
            <version>1.0.0-Alpha1</version>
        </plugin>
    </plugins>
</build>
```
To start the server:
```bash
mvn payara-server:start -DpayaraVersion=6.2024.12
```