### PR TITLE
FISH-10241/FISH-10425 Dev mode and Config support in Payara Server Maven Plugin

### DIFF
--- a/payara-maven-plugins-common/pom.xml
+++ b/payara-maven-plugins-common/pom.xml
@@ -148,12 +148,12 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>4.22.0</version>
+            <version>4.30.0</version>
         </dependency>
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>5.9.1</version>
+            <version>6.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>

--- a/payara-maven-plugins-common/src/main/java/fish/payara/maven/plugins/LogUtils.java
+++ b/payara-maven-plugins-common/src/main/java/fish/payara/maven/plugins/LogUtils.java
@@ -36,7 +36,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-package fish.payara.maven.plugins.micro;
+package fish.payara.maven.plugins;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/StartMojo.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/StartMojo.java
@@ -38,6 +38,7 @@
  */
 package fish.payara.maven.plugins.micro;
 
+import fish.payara.maven.plugins.LogUtils;
 import fish.payara.maven.plugins.AutoDeployHandler;
 import fish.payara.maven.plugins.PropertiesUtils;
 import fish.payara.maven.plugins.StartTask;

--- a/payara-server-maven-plugin/pom.xml
+++ b/payara-server-maven-plugin/pom.xml
@@ -146,6 +146,11 @@
     </build>
     <dependencies>
         <dependency>
+            <groupId>fish.payara.maven.plugins</groupId>
+            <artifactId>payara-maven-plugins-common</artifactId>
+            <version>1.0-Alpha5-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <version>3.13.1</version>
@@ -171,11 +176,11 @@
             <artifactId>mojo-executor</artifactId>
             <version>2.4.0</version>
         </dependency>
-<dependency>
-    <groupId>org.json</groupId>
-    <artifactId>json</artifactId>
-    <version>20240303</version>
-</dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20240303</version>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.maven.plugin-testing</groupId>
@@ -204,11 +209,6 @@
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-invoker</artifactId>
             <version>3.2.0</version>
-        </dependency>
-        <dependency>
-            <groupId>fish.payara.maven.plugins</groupId>
-            <artifactId>payara-maven-plugins-common</artifactId>
-            <version>1.0-Alpha4</version>
         </dependency>
         <dependency>
             <groupId>jakarta.xml.bind</groupId>

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/Command.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/Command.java
@@ -111,6 +111,10 @@ public class Command {
         return hotDeploy;
     }
 
+    public void setHotDeploy(boolean hotDeploy) {
+        this.hotDeploy = hotDeploy;
+    }
+
     public String getInstanceName() {
         return instanceName;
     }

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/DevMojo.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/DevMojo.java
@@ -1,0 +1,70 @@
+/*
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.maven.plugins.server;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+
+/**
+ * Run mojo that executes payara-server in dev mode
+ *
+ * @author Gaurav Gupta
+ */
+@Mojo(name = "dev")
+public class DevMojo extends StartMojo {
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        deployWar = true;
+        exploded = true;
+        if (autoDeploy == null) {
+            autoDeploy = true;
+        }
+        if (liveReload == null) {
+            liveReload = true;
+        }
+        if (keepState == null) {
+            keepState = true;
+        }
+        if (trimLog == null) {
+            trimLog = true;
+        }
+        super.execute();
+    }
+}

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/Option.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/Option.java
@@ -1,0 +1,69 @@
+/*
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.maven.plugins.server;
+
+public class Option {
+
+    private String key;
+    private String value;
+
+    public Option() {
+    }
+
+    public Option(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/ServerAutoDeployHandler.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/ServerAutoDeployHandler.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+package fish.payara.maven.plugins.server;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.maven.plugin.MojoExecutionException;
+import fish.payara.maven.plugins.AutoDeployHandler;
+import fish.payara.maven.plugins.Source;
+import fish.payara.maven.plugins.WebDriverFactory;
+
+/**
+ *
+ * @author Gaurav Gupta
+ */
+public class ServerAutoDeployHandler extends AutoDeployHandler {
+
+    private final StartMojo start;
+
+    public ServerAutoDeployHandler(StartMojo start, File webappDirectory) {
+        super(start, webappDirectory);
+        this.start = start;
+
+    }
+
+    @Override
+    public void reload(boolean rebootRequired) {
+        start.deployApplication();
+        WebDriverFactory.updateTitle(RELOADING, project, start.getDriver(), log);
+    }
+
+}

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/ServerAutoDeployHandler.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/ServerAutoDeployHandler.java
@@ -62,8 +62,9 @@ public class ServerAutoDeployHandler extends AutoDeployHandler {
 
     @Override
     public void reload(boolean rebootRequired) {
-        start.deployApplication();
         WebDriverFactory.updateTitle(RELOADING, project, start.getDriver(), log);
+        start.deployApplication();
+        WebDriverFactory.updateTitle("", project, start.getDriver(), log);
     }
 
 }

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/StartMojo.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/StartMojo.java
@@ -632,7 +632,6 @@ public class StartMojo extends ServerMojo implements StartTask {
     }
 
     private void openApp() {
-        System.out.println("openApp openApp openApp openApp *********");
         try {
             driver = WebDriverFactory.createWebDriver(browser, getLog());
             String url = PropertiesUtils.getProperty(applicationURL, applicationURL);

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/StartMojo.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/StartMojo.java
@@ -303,7 +303,7 @@ public class StartMojo extends ServerMojo implements StartTask {
 
     public void deployApplication() {
         serverManager.undeployApplication(projectName, instanceName);
-        URI appUri = serverManager.deployApplication(projectName, appPath, instanceName, contextRoot);
+        URI appUri = serverManager.deployApplication(projectName, appPath, instanceName, contextRoot, exploded, hotDeploy);
         if (appUri != null) {
             applicationURL = appUri.toString();
         }
@@ -504,8 +504,7 @@ public class StartMojo extends ServerMojo implements StartTask {
                                 getLog().info(repsonse);
                             }
                         } else if (userQuery.equals("deploy")) {
-                            serverManager.undeployApplication(projectName, instanceName);
-                            serverManager.deployApplication(projectName, appPath, instanceName, contextRoot);
+                            deployApplication();
                         } else if (userQuery.equals("undeploy")) {
                             serverManager.undeployApplication(projectName, instanceName);
                         } else if (userQuery.equals("exit")) {
@@ -633,6 +632,7 @@ public class StartMojo extends ServerMojo implements StartTask {
     }
 
     private void openApp() {
+        System.out.println("openApp openApp openApp openApp *********");
         try {
             driver = WebDriverFactory.createWebDriver(browser, getLog());
             String url = PropertiesUtils.getProperty(applicationURL, applicationURL);

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/manager/InstanceManager.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/manager/InstanceManager.java
@@ -253,7 +253,7 @@ public class InstanceManager<X extends PayaraServerInstance> {
         return false;
     }
 
-    public void deployApplication(String name, String appPath, String instanceName, String contextRoot) {
+    public URI deployApplication(String name, String appPath, String instanceName, String contextRoot) {
         Command command = new Command(ASADMIN_PATH, DEPLOY_COMMAND, name);
         command.setPath(appPath);
         command.setContextRoot(contextRoot);
@@ -272,6 +272,7 @@ public class InstanceManager<X extends PayaraServerInstance> {
                             payaraServer.getProtocol().equals("http") ? payaraServer.getHttpPort() : payaraServer.getHttpPort(),
                             getContextRoot(((JsonResponse) response).getJsonBody()), null, null);
                     log.info(name + " application deployed successfully : " + app.toString());
+                    return app;
                 } else {
                     log.info(name + " application deployed successfully.");
                 }
@@ -281,6 +282,7 @@ public class InstanceManager<X extends PayaraServerInstance> {
         } catch (Exception ex) {
             log.error("Error deploying the application: " + ex.getMessage());
         }
+        return null;
     }
 
     public String getContextRoot(JSONObject body) {


### PR DESCRIPTION
### Dev Mode Support

This pull request enhances the Payara Server Maven plugin for Payara Server by introducing a new `dev` mode goal.

To test it, start a Payara Server instance and use the following command to activate dev mode:
```
mvn install payara-server:dev 
```

Which is equivalent to activating auto-deploy with hot-deploy, use the following command:
````
mvn install payara-server:start -DautoDeploy=true -DliveReload=true -DdeployWar=true -Dexploded=true
````

Modify the source code, and it should automatically deploy and refresh the browser page.

=============================================


### Command Line Options Support
This pull request also introduces support for additional configuration options:

#### `javaCommandLineOptions`
**Default:** None  
Defines a list of command-line options that will be passed to the Java executable. Options can be defined as key-value pairs or as a list of values. Key-value pairs will be formatted as `key=value`.

#### `commandLineOptions`
**Default:** None  
Defines a list of command-line options that will be passed onto Payara Server.

**Example Configuration:**
```xml
<configuration>
    <javaCommandLineOptions>
        <option>
            <key>-DMY_ENV_VAR</key>
            <value>myValue</value>
        </option>
    </javaCommandLineOptions>
    <commandLineOptions>
        <option>
            <key>MY_PROP_VAR</key>
            <value>myPROPValue</value>
        </option>
    </commandLineOptions>
</configuration>
