### PR TITLE
FISH-10856 Payara Server Start Operation Fails if Path Contains Spaces

### DIFF
--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/manager/LocalInstanceManager.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/manager/LocalInstanceManager.java
@@ -125,6 +125,9 @@ public class LocalInstanceManager extends InstanceManager<PayaraServerLocalInsta
         if (!Files.exists(Paths.get(bootstrapJar))) {
             throw new Exception(ERROR_BOOTSTRAP_JAR_NOT_FOUND);
         }
+        if (bootstrapJar.contains(" ")) {
+            bootstrapJar = "\"" + bootstrapJar + "\"";
+        }
         String classPath = "";
         String javaOpts;
         String payaraArgs;
@@ -206,11 +209,16 @@ public class LocalInstanceManager extends InstanceManager<PayaraServerLocalInsta
             if (splitIndex != -1 && !opt.startsWith("-agentpath:")) {
                 name = opt.substring(0, splitIndex);
                 value = StringUtils.quote(opt.substring(splitIndex + 1));
+            } else if(opt.startsWith("-Xbootclasspath")) {
+                splitIndex = opt.indexOf(':');
+                name = opt.substring(0, splitIndex);
+                value = StringUtils.quote(opt.substring(splitIndex + 1));
+                opt = name + ':' + value;
             } else {
                 name = opt;
             }
 
-            if (name.startsWith("--add-")) {
+            if (opt.startsWith("--add-") || opt.startsWith("-Xbootclasspath")) {
                 moduleOptions.add(opt);
             } else {
                 if (!keyValueArgs.containsKey(name)) {
@@ -247,6 +255,7 @@ public class LocalInstanceManager extends InstanceManager<PayaraServerLocalInsta
         return String.join(" ", payaraArgsList).trim();
     }
 
+    @Override
     public boolean isServerAlreadyRunning() {
         Command command = new Command(ASADMIN_PATH, LOCATIONS_COMMAND, null);
         Response serverRunning;


### PR DESCRIPTION

Added the payara-server-maven-plugin to the pom.xml:
```
<plugin>
    <groupId>fish.payara.maven.plugins</groupId>
    <artifactId>payara-server-maven-plugin</artifactId>
    <version>1.0.0-Alpha1</version>
</plugin>
```

Run the application using:
```
mvn install payara-server:start
```

Ensure the application path (i.e., project directory) has spaces in it to verify correct behavior.