### PR TITLE
FISH-10921 Payara AI Agent integration

### DIFF
--- a/payara-server-maven-plugin/pom.xml
+++ b/payara-server-maven-plugin/pom.xml
@@ -218,7 +218,7 @@
         <dependency>
             <groupId>fish.payara.tools</groupId>
             <artifactId>payara-ai-agent</artifactId>
-            <version>1.0-Alpha1-SNAPSHOT</version>
+            <version>1.0.0-Alpha1</version>
         </dependency>
     </dependencies>
 

--- a/payara-server-maven-plugin/pom.xml
+++ b/payara-server-maven-plugin/pom.xml
@@ -215,6 +215,11 @@
             <artifactId>jakarta.xml.bind-api</artifactId>
             <version>4.0.2</version>
         </dependency>
+        <dependency>
+            <groupId>fish.payara.tools</groupId>
+            <artifactId>payara-ai-agent</artifactId>
+            <version>1.0-Alpha1-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/DevMojo.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/DevMojo.java
@@ -64,6 +64,9 @@ public class DevMojo extends StartMojo {
         if (trimLog == null) {
             trimLog = true;
         }
+        if (aiAgent == null) {
+            aiAgent = true;
+        }
         super.execute();
     }
 }

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/StartMojo.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/StartMojo.java
@@ -165,7 +165,7 @@ public class StartMojo extends ServerMojo implements StartTask {
     
     @Parameter(property = "payara.ai.agent", defaultValue = "${env.PAYARA_AI_AGENT}")
     protected Boolean aiAgent;
-    
+
     /**
      * Additional command-line options for Payara server.
      */
@@ -604,6 +604,7 @@ public class StartMojo extends ServerMojo implements StartTask {
                                 enableMonitoring();
                                 StringBuilder sb = new StringBuilder();
                                 for (String endpoint : payaraAIAgent.getRestEndpoint(response)) {
+                                    endpoint = endpoint.replace("${appname}", projectName);
                                     sb.append(endpoint).append('\n');
                                     Response res = serverManager.runEndpoint(endpoint);
                                     if (res != null) {

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/manager/InstanceManager.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/manager/InstanceManager.java
@@ -555,6 +555,9 @@ private InputStream getInputStream(Command command) {
     }
 
     private String constructCommandUrl(PayaraServerInstance server, Command command) throws IllegalStateException {
+        if(command.getCommand().startsWith("http")) {
+            return command.getCommand();
+        }
         URI uri;
         try {
             uri = new URI(server.getProtocol(), null, server.getHost(), server.getAdminPort(),

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/manager/LocalInstanceManager.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/manager/LocalInstanceManager.java
@@ -77,7 +77,7 @@ public class LocalInstanceManager extends InstanceManager<PayaraServerLocalInsta
     }
 
     public ProcessBuilder startServer(String debug, String debugPort, List<Option> javaCommandLineOptions, List<Option> commandLineOptions) throws Exception {
-        JvmConfigReader jvmConfigReader = new JvmConfigReader(payaraServer.getDomainXmlPath(), DAS_NAME);
+        JvmConfigReader jvmConfigReader = new JvmConfigReader(payaraServer.getDomainXml(), DAS_NAME);
         String javaHome = payaraServer.getJDKHome();
         if (javaHome == null) {
             throw new Exception(ERROR_JAVA_HOME_NOT_FOUND);

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/response/JsonResponse.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/response/JsonResponse.java
@@ -40,7 +40,6 @@ package fish.payara.maven.plugins.server.response;
 
 import java.util.List;
 import java.util.Map;
-import org.json.JSONArray;
 import org.json.JSONObject;
 
 /**


### PR DESCRIPTION
# Payara AI Agent - Configuration

This PR integrate with AI Agent and describes the environment variables and system properties available for configuring the Payara AI Agent.

The configuration values can be provided **either** via **environment variables** or **system properties**.  


---

## Available Configuration Options

| Environment Variable              | System Property               | Description |
|:-----------------------------------|:-------------------------------|:------------|
| `PAYARA_AI_API_KEY`                | `payara.ai.api.key`            | API Key for authentication with the AI provider. |
| `PAYARA_AI_PROVIDER_LOCATION`      | `payara.ai.provider.location`  | Base URL or endpoint of the AI provider. |
| `PAYARA_AI_PROVIDER`               | `payara.ai.provider`           | Name or identifier of the AI provider (e.g., `OpenAI`, `Anthropic`, etc.). |
| `PAYARA_AI_MODEL`                  | `payara.ai.model`              | Name of the model to be used for AI requests. |
| `PAYARA_AI_TEMPERATURE`            | `payara.ai.temperature`        | Sampling temperature to control randomness. A value between `0.0` (deterministic) and `1.0` (creative). |
| `PAYARA_AI_TOP_P`                  | `payara.ai.topP`               | Nucleus sampling parameter (top-p). Specifies the cumulative probability cutoff for token selection. |
| `PAYARA_AI_STREAM`                 | `payara.ai.stream`             | Whether to enable streaming of partial outputs (`true` or `false`). |
| `PAYARA_AI_TIMEOUT`                | `payara.ai.timeout`            | Request timeout in milliseconds. |
| `PAYARA_AI_LOG_REQUESTS`           | `payara.ai.log.requests`       | Whether to log outgoing requests (`true` or `false`). |
| `PAYARA_AI_LOG_RESPONSES`          | `payara.ai.log.responses`      | Whether to log incoming responses (`true` or `false`). |
| `PAYARA_AI_REPEAT_PENALTY`         | `payara.ai.repeat.penalty`     | Penalty for repeating tokens; helps control repetition. |

---

## Example Usage

You can set the configuration using environment variables:

```bash
export PAYARA_AI_API_KEY="your-api-key"
export PAYARA_AI_PROVIDER="OpenAI"
export PAYARA_AI_MODEL="gpt-4"
export PAYARA_AI_TEMPERATURE="0.7"
```

Or using system properties when starting your application:

```bash
java -Dpayara.ai.api.key=your-api-key \
     -Dpayara.ai.provider=OpenAI \
     -Dpayara.ai.model=gpt-4 \
     -Dpayara.ai.temperature=0.7 \
     -jar your-application.jar
```

---
## Minimal Setup

The minimal configuration is to set the OpenAI key using the `PAYARA_AI_API_KEY` environment variable.  
By default, the client will use OpenAI as the provider.

To start:

1. Set the environment variable `PAYARA_AI_API_KEY` with your OpenAI API key.
2. Start the server instance with:
   ```bash
   mvn install payara-server:dev
   ```
   or 
    ```bash
   mvn install payara-server:start -Dpayara.ai.agent=true
   ```
3. Once the server has started and your application is deployed, you can start asking questions.

This integration may assist in creating admin commands and providing server insights automatically.


---

Note : This PR depends on https://github.com/payara/ecosystem-ai
