### PR TITLE
FISH-11608 Authentication error message handling

### DIFF
--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/StartMojo.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/StartMojo.java
@@ -66,6 +66,7 @@ import java.util.concurrent.TimeUnit;
 
 import static fish.payara.maven.plugins.server.Configuration.*;
 import fish.payara.maven.plugins.server.manager.PayaraServerInstance;
+import static fish.payara.maven.plugins.server.manager.PayaraServerLocalInstance.HTTP;
 import fish.payara.maven.plugins.server.response.JsonResponse;
 import fish.payara.maven.plugins.server.response.Response;
 import fish.payara.maven.plugins.server.utils.TempDirectoryResolver;
@@ -852,7 +853,7 @@ public class StartMojo extends ServerMojo implements StartTask {
             driver = WebDriverFactory.createWebDriver(browser, getLog());
             String url = PropertiesUtils.getProperty(applicationURL, applicationURL);
             if ((url == null || url.isEmpty())) {
-                url = instance.getProtocol() + "://" + instance.getHost() + ":" + (instance.getProtocol().equals("http") ? instance.getHttpPort() : instance.getHttpPort());
+                url = instance.getProtocol() + "://" + instance.getHost() + ":" + (instance.getProtocol().equals(HTTP) ? instance.getHttpPort() : instance.getHttpsPort());
                 if (contextRoot != null) {
                     url = url + "/" + contextRoot;
                 }

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/manager/InstanceManager.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/manager/InstanceManager.java
@@ -411,8 +411,9 @@ public class InstanceManager<X extends PayaraServerInstance> {
         if(respCode == HttpURLConnection.HTTP_MOVED_TEMP) {
             String location = hconn.getHeaderField("Location");
             if (location.startsWith("https://") && hconn.getURL().toString().startsWith("http://")) {
-                return new PlainResponse("Authentication failed: Please set the admin username and password. The server redirected to a secure login page, indicating credentials are required.",
-                        respCode, hconn.getHeaderFields());
+                URL secureUrl = new URL(location);
+                URLConnection newConn = secureUrl.openConnection();
+                return handleHTTPConnection(instance, command, newConn, secureUrl);
             }
         }
 

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/manager/InstanceManager.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/manager/InstanceManager.java
@@ -218,14 +218,9 @@ public class InstanceManager<X extends PayaraServerInstance> {
     }
 
     public boolean pingServer() throws Exception {
-        URI uri = new URI(payaraServer.getProtocol(), null, payaraServer.getHost(), payaraServer.getAdminPort(),
-                MANAGEMENT_PATH + VERSION_COMMAND, null, null);
-        HttpURLConnection connection = (HttpURLConnection) uri.toURL().openConnection();
-        connection.setRequestMethod(HTTP_GET_METHOD);
-        connection.setConnectTimeout(payaraServer.getHttpConnectionTimeout());
-        connection.setReadTimeout(payaraServer.getHttpReadTimeout());
-        int responseCode = connection.getResponseCode();
-        return (responseCode == HttpURLConnection.HTTP_OK);
+        Command command = new Command(MANAGEMENT_PATH, VERSION_COMMAND, null);
+        Response response = invokeServer(payaraServer, command);
+        return response != null && response.isExitCodeSuccess();
     }
 
     public boolean isServerAlreadyRunning() {

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/manager/InstanceManager.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/manager/InstanceManager.java
@@ -109,7 +109,7 @@ public class InstanceManager<X extends PayaraServerInstance> {
     public static final String CONTENT_TYPE_HTML_TEXT = "text/html";
     private static final String CONTENT_TYPE_HEADER = "Content-Type";
 
-    private static final int MAX_RETRIES = 60;
+    private static final int MAX_RETRIES = 100;
     /**
      * Delay before administration command execution will be retried.
      */

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/manager/PayaraServerLocalInstance.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/manager/PayaraServerLocalInstance.java
@@ -56,6 +56,18 @@ import java.nio.file.Paths;
  * @author Gaurav Gupta
  */
 public class PayaraServerLocalInstance extends PayaraServerInstance {
+    
+    
+    public static final String GLASSFISH_DIR = "glassfish";
+    public static final String MODULES_DIR = "modules";
+    public static final String DOMAINS_DIR = "domains";
+    public static final String CONFIG_DIR = "config";
+    public static final String LOGS_DIR = "logs";
+    public static final String SERVER_LOG = "server.log";
+    public static final String DOMAIN_XML = "domain.xml";
+    public static final String HTTPS = "https";
+    public static final String HTTP = "http";
+    public static final String LOCALHOST = "localhost";
 
     private PortReader portReader;
     private Process logStream;
@@ -87,15 +99,15 @@ public class PayaraServerLocalInstance extends PayaraServerInstance {
     }
 
     public String getServerHome() {
-        return Paths.get(getServerRoot(), "glassfish").toString();
+        return Paths.get(getServerRoot(), GLASSFISH_DIR).toString();
     }
 
     public String getServerModules() {
-        return Paths.get(getServerHome(), "modules").toString();
+        return Paths.get(getServerHome(), MODULES_DIR).toString();
     }
 
     public String getDomainsFolder() {
-        return Paths.get(getServerHome(), "domains").toString();
+        return Paths.get(getServerHome(), DOMAINS_DIR).toString();
     }
 
     public String getDomainPath() {
@@ -103,11 +115,11 @@ public class PayaraServerLocalInstance extends PayaraServerInstance {
     }
 
     public String getDomainXml() {
-        return Paths.get(getDomainPath(), "config", "domain.xml").toString();
+        return Paths.get(getDomainPath(), CONFIG_DIR, DOMAIN_XML).toString();
     }
 
     public String getServerLog() {
-        return Paths.get(getDomainPath(), "logs", "server.log").toString();
+        return Paths.get(getDomainPath(), LOGS_DIR, SERVER_LOG).toString();
     }
 
     public String readServerLog() throws IOException {
@@ -127,8 +139,7 @@ public class PayaraServerLocalInstance extends PayaraServerInstance {
      * Helper to read any file as UTF-8, replacing malformed or unmappable input.
      */
     private String readFileWithReplacement(String filePath) throws IOException {
-        Path path = Paths.get(filePath);
-        byte[] raw = Files.readAllBytes(path);
+        byte[] raw = Files.readAllBytes(Paths.get(filePath));
 
         CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder()
             .onMalformedInput(CodingErrorAction.REPLACE)
@@ -151,12 +162,19 @@ public class PayaraServerLocalInstance extends PayaraServerInstance {
 
     @Override
     public String getProtocol() {
-        return protocol == null ? "http" : protocol;
+        if(protocol == null) {
+            if (adminUser == null) {
+                return HTTP;
+            } else {
+                return HTTPS;
+            }
+        } 
+        return protocol;
     }
 
     @Override
     public String getHost() {
-        return host == null ? "localhost" : host;
+        return host == null ? LOCALHOST : host;
     }
 
     @Override

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/manager/PayaraServerLocalInstance.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/manager/PayaraServerLocalInstance.java
@@ -162,13 +162,9 @@ public class PayaraServerLocalInstance extends PayaraServerInstance {
 
     @Override
     public String getProtocol() {
-        if(protocol == null) {
-            if (adminUser == null) {
-                return HTTP;
-            } else {
-                return HTTPS;
-            }
-        } 
+        if (protocol == null) {
+            return HTTP;
+        }
         return protocol;
     }
 

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/manager/PayaraServerLocalInstance.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/manager/PayaraServerLocalInstance.java
@@ -48,7 +48,6 @@ import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 
 /**
@@ -67,6 +66,9 @@ public class PayaraServerLocalInstance extends PayaraServerInstance {
     public static final String DOMAIN_XML = "domain.xml";
     public static final String HTTPS = "https";
     public static final String HTTP = "http";
+    public static final String HTTPS_PREFIX = "https://";
+    public static final String HTTP_PREFIX = "http://";
+    public static final String LOCATION_HEADER = "Location";
     public static final String LOCALHOST = "localhost";
 
     private PortReader portReader;


### PR DESCRIPTION
This PR sets up and verifies usage of the `payara-server-maven-plugin` with secure admin enabled in Payara Server.

### 🔧 Setup Steps

1. **Start the Payara Domain**
   ```bash
   asadmin start-domain domain1
   ```

2. **Change Admin Password**
   Run the following command and update the password when prompted:
   ```bash
   asadmin change-admin-password
   ```

3. **Enable Secure Admin**
   ```bash
   asadmin enable-secure-admin
   ```

4. **Stop the Domain**
   ```bash
   asadmin stop-domain domain1
   ```

---

### 🚀 Run Maven Command to Test Deployment

```bash
mvn package fish.payara.maven.plugins:payara-server-maven-plugin:1.0.0-Alpha3-SNAPSHOT:dev \
  -Dpayara.server.path="D:\Software\payara-web-6.2025.7\payara6" \
  -Dpayara.admin.user=admin \
  -Dpayara.admin.password=admin
```

---

### ✅ Expected Outcome

Successful connection to Payara Server with secure admin enabled, allowing deployment using the Maven plugin.
