### PR TITLE
FISH-11024 Payara Server/Micro Maven Plugin devmode - option to ignore test files

### DIFF
--- a/payara-maven-plugins-common/src/main/java/fish/payara/maven/plugins/AutoDeployHandler.java
+++ b/payara-maven-plugins-common/src/main/java/fish/payara/maven/plugins/AutoDeployHandler.java
@@ -168,9 +168,10 @@ public abstract class AutoDeployHandler implements Runnable {
                 }
             }));
             // Create a set of paths to ignore that are directories
-            Set<Path> ignoredDirectories = Set.of(
-                    buildPath, ideaPath, eclipsePath, vscodePath
-            );
+            Path testSourceDirectory = project.getBasedir().toPath().resolve(SRC_DIR).resolve(TEST_DIR);
+            Set<Path> ignoredDirectories = start.isIgnoreTestChanges()
+                    ? Set.of(buildPath, ideaPath, eclipsePath, vscodePath, testSourceDirectory)
+                    : Set.of(buildPath, ideaPath, eclipsePath, vscodePath);
 
             // Create a set of specific files to ignore
             Set<Path> ignoredFiles = Set.of(

--- a/payara-maven-plugins-common/src/main/java/fish/payara/maven/plugins/StartTask.java
+++ b/payara-maven-plugins-common/src/main/java/fish/payara/maven/plugins/StartTask.java
@@ -24,4 +24,6 @@ public interface StartTask {
      WebDriver getDriver();
      
      boolean isLocal();
+
+     boolean isIgnoreTestChanges();
 }

--- a/payara-micro-maven-plugin/pom.xml
+++ b/payara-micro-maven-plugin/pom.xml
@@ -234,7 +234,7 @@
         <dependency>
             <groupId>fish.payara.maven.plugins</groupId>
             <artifactId>payara-maven-plugins-common</artifactId>
-            <version>1.0.0-Alpha5</version>
+            <version>1.0.0-Alpha6-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/StartMojo.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/StartMojo.java
@@ -144,6 +144,9 @@ public class StartMojo extends BasePayaraMojo implements StartTask {
     @Parameter(property = "payara.auto.deploy", defaultValue = "${env.PAYARA_AUTO_DEPLOY}")
     protected Boolean autoDeploy;
 
+    @Parameter(property = "payara.ignore.test.changes", defaultValue = "${env.PAYARA_IGNORE_TEST_CHANGES}")
+    protected boolean ignoreTestChanges = true;
+
     @Parameter(property = "payara.keep.state", defaultValue = "${env.PAYARA_KEEP_STATE}")
     protected Boolean keepState;
 
@@ -759,6 +762,11 @@ public class StartMojo extends BasePayaraMojo implements StartTask {
     @Override
     public boolean isLocal() {
         return exploded;
+    }
+
+    @Override
+    public boolean isIgnoreTestChanges() {
+        return ignoreTestChanges;
     }
 
 }

--- a/payara-server-maven-plugin/pom.xml
+++ b/payara-server-maven-plugin/pom.xml
@@ -154,7 +154,7 @@
         <dependency>
             <groupId>fish.payara.maven.plugins</groupId>
             <artifactId>payara-maven-plugins-common</artifactId>
-            <version>1.0.0-Alpha5</version>
+            <version>1.0.0-Alpha6-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>

--- a/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/StartMojo.java
+++ b/payara-server-maven-plugin/src/main/java/fish/payara/maven/plugins/server/StartMojo.java
@@ -116,6 +116,12 @@ public class StartMojo extends ServerMojo implements StartTask {
     protected Boolean autoDeploy;
 
     /**
+     * When true, changes in src/test are ignored and do not trigger a redeployment.
+     */
+    @Parameter(property = "payara.ignore.test.changes", defaultValue = "${env.PAYARA_IGNORE_TEST_CHANGES}")
+    protected boolean ignoreTestChanges = true;
+
+    /**
      * Keeps the current state of the Payara server on restart.
      */
     @Parameter(property = "payara.keep.state", defaultValue = "${env.PAYARA_KEEP_STATE}")
@@ -911,6 +917,11 @@ public class StartMojo extends ServerMojo implements StartTask {
     @Override
     public boolean isLocal() {
         return exploded;
+    }
+
+    @Override
+    public boolean isIgnoreTestChanges() {
+        return ignoreTestChanges;
     }
 
 }


### PR DESCRIPTION
Adds an `ignoreTestChanges` parameter to both the Payara Server and Payara Micro Maven plugins. When enabled (the
  default), changes under `src/test/` no longer trigger a redeployment during `devmode (autoDeploy=true)`, avoiding
  unnecessary rebuild cycles when editing tests.